### PR TITLE
Some usability improvements for `project_traceout!()`

### DIFF
--- a/src/backends/quantumoptics/quantumoptics.jl
+++ b/src/backends/quantumoptics/quantumoptics.jl
@@ -37,7 +37,7 @@ function observable(state::Union{<:Ket,<:Operator}, indices, operation)
     expect(op, state)
 end
 
-function project_traceout!(state::Union{Ket,Operator},stateindex,psis::Union{Tuple{ZBasisState, ZBasisState},Vector{<:Ket}})
+function project_traceout!(state::Union{Ket,Operator},stateindex,psis::Union{Tuple,Vector{<:Ket}})
     if nsubsystems(state) == 1 # TODO is there a way to do this in a single function, instead of _overlap vs _project_and_drop
         _overlaps = [_overlap(psi,state) for psi in psis]
         branch_probs = cumsum(_overlaps)

--- a/src/backends/quantumoptics/quantumoptics.jl
+++ b/src/backends/quantumoptics/quantumoptics.jl
@@ -41,7 +41,9 @@ function project_traceout!(state::Union{Ket,Operator},stateindex,psis::Union{Tup
     if nsubsystems(state) == 1 # TODO is there a way to do this in a single function, instead of _overlap vs _project_and_drop
         _overlaps = [_overlap(psi,state) for psi in psis]
         branch_probs = cumsum(_overlaps)
-        @assert branch_probs[end] ≈ 1.0
+        if !(branch_probs[end] ≈ 1.0)
+            throw("State not normalized. Could be due to passing wrong state to `initialize!`")
+        end
         j = findfirst(>=(rand()), branch_probs) # TODO what if there is numerical imprecision and sum<1
         j, nothing
     else

--- a/src/backends/quantumoptics/quantumoptics.jl
+++ b/src/backends/quantumoptics/quantumoptics.jl
@@ -37,7 +37,7 @@ function observable(state::Union{<:Ket,<:Operator}, indices, operation)
     expect(op, state)
 end
 
-function project_traceout!(state::Union{Ket,Operator},stateindex,psis::Vector{<:Ket})
+function project_traceout!(state::Union{Ket,Operator},stateindex,psis::Union{Tuple{ZBasisState, ZBasisState},Vector{<:Ket}})
     if nsubsystems(state) == 1 # TODO is there a way to do this in a single function, instead of _overlap vs _project_and_drop
         _overlaps = [_overlap(psi,state) for psi in psis]
         branch_probs = cumsum(_overlaps)

--- a/src/backends/quantumoptics/quantumoptics.jl
+++ b/src/backends/quantumoptics/quantumoptics.jl
@@ -37,7 +37,7 @@ function observable(state::Union{<:Ket,<:Operator}, indices, operation)
     expect(op, state)
 end
 
-function project_traceout!(state::Union{Ket,Operator},stateindex,psis::Union{Tuple,Vector{<:Ket}})
+function project_traceout!(state::Union{Ket,Operator},stateindex,psis::Base.AbstractVecOrTuple{Ket})
     if nsubsystems(state) == 1 # TODO is there a way to do this in a single function, instead of _overlap vs _project_and_drop
         _overlaps = [_overlap(psi,state) for psi in psis]
         branch_probs = cumsum(_overlaps)

--- a/test/test_project_traceout.jl
+++ b/test/test_project_traceout.jl
@@ -27,3 +27,7 @@ for rep in [QuantumOpticsRepr(), CliffordRepr()]
     initialize!(a[1], X1)
     @test project_traceout!(a[1], σˣ) == 1
 end
+
+r = Register(1)
+initialize!(r[1], Z)
+@test_throws "State not normalized. Could be due to passing wrong state to `initialize!`" project_traceout!(r[1], (L0, L1))


### PR DESCRIPTION
Allows `project_traceout()` to accept Tuples of possible basis states. Also added a more descriptive error message when the state to be measured is not normalized.