### PR TITLE
Entanglement simulation on a grid with custom predicates

### DIFF
--- a/examples/firstgenrepeater_v2/2_swapper_example.jl
+++ b/examples/firstgenrepeater_v2/2_swapper_example.jl
@@ -20,7 +20,7 @@ for (;src, dst) in edges(network)
     @process eprot()
 end
 for node in vertices(network)
-    sprot = SwapperProt(sim, network, node; nodeL = <(node), nodeH = >(node), chooseL = findmin, chooseH = findmax)
+    sprot = SwapperProt(sim, network, node; nodeL = <(node), nodeH = >(node), chooseL = argmin, chooseH = argmax)
     @process sprot()
 end
 

--- a/examples/firstgenrepeater_v2/2_swapper_example.jl
+++ b/examples/firstgenrepeater_v2/2_swapper_example.jl
@@ -20,7 +20,7 @@ for (;src, dst) in edges(network)
     @process eprot()
 end
 for node in vertices(network)
-    sprot = SwapperProt(sim, network, node; nodeL = <(node), nodeR = >(node))
+    sprot = SwapperProt(sim, network, node; nodeL = <(node), nodeH = >(node))
     @process sprot()
 end
 

--- a/examples/firstgenrepeater_v2/2_swapper_example.jl
+++ b/examples/firstgenrepeater_v2/2_swapper_example.jl
@@ -20,7 +20,7 @@ for (;src, dst) in edges(network)
     @process eprot()
 end
 for node in vertices(network)
-    sprot = SwapperProt(sim, network, node; nodeL = <(node), nodeH = >(node))
+    sprot = SwapperProt(sim, network, node; nodeL = <(node), nodeH = >(node), chooseL = argmin, chooseH = argmax)
     @process sprot()
 end
 

--- a/examples/firstgenrepeater_v2/2_swapper_example.jl
+++ b/examples/firstgenrepeater_v2/2_swapper_example.jl
@@ -20,7 +20,7 @@ for (;src, dst) in edges(network)
     @process eprot()
 end
 for node in vertices(network)
-    sprot = SwapperProt(sim, network, node; nodeL = <(node), nodeH = >(node), chooseL = argmin, chooseH = argmax)
+    sprot = SwapperProt(sim, network, node; nodeL = <(node), nodeH = >(node), chooseL = findmin, chooseH = findmax)
     @process sprot()
 end
 

--- a/src/ProtocolZoo/ProtocolZoo.jl
+++ b/src/ProtocolZoo/ProtocolZoo.jl
@@ -215,13 +215,8 @@ end
 function findswapablequbits(net, node, pred_low, pred_high) # TODO parameterize the query predicates and the findmin/findmax
     reg = net[node]
     
-    if typeof(pred_low) == Wildcard
-        l = <(node)
-        h = >(node)
-    else
-        l(x) = pred_low(net, node, x)
-        h(x) = pred_high(net, node, x)
-    end
+    l = typeof(pred_low) == Wildcard ? <(node) : pred_low
+    h = typeof(pred_high) == Wildcard ? >(node) : pred_high
 
     low_nodes  = queryall(reg, EntanglementCounterpart, l, ❓; locked=false, assigned=true)
     high_nodes = queryall(reg, EntanglementCounterpart, h, ❓; locked=false, assigned=true)

--- a/src/ProtocolZoo/ProtocolZoo.jl
+++ b/src/ProtocolZoo/ProtocolZoo.jl
@@ -226,8 +226,8 @@ function findswapablequbits(net, node, pred_low, pred_high, choose_low, choose_h
     high_nodes = queryall(reg, EntanglementCounterpart, pred_high, ❓; locked=false, assigned=true)
 
     (isempty(low_nodes) || isempty(high_nodes)) && return nothing
-    _, il = choose_low(n->n.tag[2], low_nodes) # TODO make [2] into a nice named property
-    _, ih = choose_high(n->n.tag[2], high_nodes)
+    il = choose_low((n.tag[2] for n in low_nodes)) # TODO make [2] into a nice named property
+    ih = choose_high((n.tag[2] for n in high_nodes))
     return low_nodes[il], high_nodes[ih]
 end
 

--- a/src/ProtocolZoo/ProtocolZoo.jl
+++ b/src/ProtocolZoo/ProtocolZoo.jl
@@ -138,6 +138,9 @@ end
     end
 end
 
+function random_index(arr)
+    return rand(keys(arr))
+end
 
 """
 $TYPEDEF
@@ -146,17 +149,21 @@ A protocol, running at a given node, that finds swappable entangled pairs and pe
 
 $FIELDS
 """
-@kwdef struct SwapperProt{NL,NH,LT} <: AbstractProtocol where {NL<:Union{Int,<:Function,Wildcard}, NH<:Union{Int,<:Function,Wildcard}, LT<:Union{Float64,Nothing}}
+@kwdef struct SwapperProt{NL,NH,CL,CH,LT} <: AbstractProtocol where {NL<:Union{Int,<:Function,Wildcard}, NH<:Union{Int,<:Function,Wildcard}, CL<:Function, CH<:Function, LT<:Union{Float64,Nothing}}
     """time-and-schedule-tracking instance from `ConcurrentSim`"""
     sim::Simulation
     """a network graph of registers"""
     net::RegisterNet
     """the vertex of the node where swapping is happening"""
     node::Int
-    """the vertex of one of the remote nodes that is lower than the current node value (or a predicate function or a wildcard)"""
+    """the vertex of one of the remote nodes for the swap, arbitrarily refered to as the "low" node (or a predicate function or a wildcard); if you are working on a repeater chain, a good choice is `<(current_node)`, i.e. any node to the "left" of the current node"""
     nodeL::NL = ❓
-    """the vertex of the other remote node that is higher than the current node value (or a predicate function or a wildcard)"""
-    nodeH::NH = ❓
+    """the vertex of the other remote node for the swap, the "high" counterpart of `nodeL`; if you are working on a repeater chain, a good choice is `>(current_node)`, i.e. any node to the "right" of the current node"""
+    nodeH::NH = ❓ # TODO consider changing the default to random
+    """the `nodeL` predicate can return many positive candidates; `chooseL` picks one of them (by index into the array of filtered `nodeL` results), defaults to a random pick `arr->rand(keys(arr))`; if you are working on a repeater chain a good choice is `argmin`, i.e. the node furthest to the "left" """
+    chooseL::CL = random_index
+    """the `nodeH` counterpart for `chooseH`; if you are working on a repeater chain a good choice is `argmax`, i.e. the node furthest to the "right" """
+    chooseH::CH = random_index
     """fixed "busy time" duration immediately before starting entanglement generation attempts"""
     local_busy_time::Float64 = 0.0 # TODO the gates should have that busy time built in
     """how long to wait before retrying to lock qubits if no qubits are available (`nothing` for queuing up and waiting)"""
@@ -175,7 +182,7 @@ end
     rounds = prot.rounds
     while rounds != 0
         reg = prot.net[prot.node]
-        qubit_pair = findswapablequbits(prot.net,prot.node, prot.nodeL, prot.nodeH)
+        qubit_pair = findswapablequbits(prot.net, prot.node, prot.nodeL, prot.nodeH, prot.chooseL, prot.chooseH)
         if isnothing(qubit_pair)
             isnothing(prot.retry_lock_time) && error("We do not yet support waiting on register to make qubits available") # TODO
             @yield timeout(prot.sim, prot.retry_lock_time)
@@ -212,15 +219,15 @@ end
     end
 end
 
-function findswapablequbits(net, node, pred_low, pred_high) # TODO parameterize the query predicates and the findmin/findmax
+function findswapablequbits(net, node, pred_low, pred_high, choose_low, choose_high) # TODO parameterize the query predicates and the findmin/findmax
     reg = net[node]
 
     low_nodes  = queryall(reg, EntanglementCounterpart, pred_low, ❓; locked=false, assigned=true)
     high_nodes = queryall(reg, EntanglementCounterpart, pred_high, ❓; locked=false, assigned=true)
 
     (isempty(low_nodes) || isempty(high_nodes)) && return nothing
-    _, il = findmin(n->n.tag[2], low_nodes) # TODO make [2] into a nice named property
-    _, ih = findmax(n->n.tag[2], high_nodes)
+    _, il = choose_low(n->n.tag[2], low_nodes) # TODO make [2] into a nice named property
+    _, ih = choose_high(n->n.tag[2], high_nodes)
     return low_nodes[il], high_nodes[ih]
 end
 

--- a/src/ProtocolZoo/ProtocolZoo.jl
+++ b/src/ProtocolZoo/ProtocolZoo.jl
@@ -156,7 +156,7 @@ $FIELDS
     net::RegisterNet
     """the vertex of the node where swapping is happening"""
     node::Int
-    """the vertex of one of the remote nodes for the swap, arbitrarily refered to as the "low" node (or a predicate function or a wildcard); if you are working on a repeater chain, a good choice is `<(current_node)`, i.e. any node to the "left" of the current node"""
+    """the vertex of one of the remote nodes for the swap, arbitrarily referred to as the "low" node (or a predicate function or a wildcard); if you are working on a repeater chain, a good choice is `<(current_node)`, i.e. any node to the "left" of the current node"""
     nodeL::NL = ❓
     """the vertex of the other remote node for the swap, the "high" counterpart of `nodeL`; if you are working on a repeater chain, a good choice is `>(current_node)`, i.e. any node to the "right" of the current node"""
     nodeH::NH = ❓ # TODO consider changing the default to random

--- a/src/ProtocolZoo/ProtocolZoo.jl
+++ b/src/ProtocolZoo/ProtocolZoo.jl
@@ -217,7 +217,7 @@ function findswapablequbits(net, node, pred_low, pred_high) # TODO parameterize 
     
     if typeof(pred_low) == Wildcard
         l = <(node)
-        r = >(node)
+        h = >(node)
     else
         l(x) = pred_low(net, node, x)
         h(x) = pred_high(net, node, x)

--- a/src/ProtocolZoo/ProtocolZoo.jl
+++ b/src/ProtocolZoo/ProtocolZoo.jl
@@ -159,7 +159,7 @@ $FIELDS
     """the vertex of one of the remote nodes for the swap, arbitrarily referred to as the "low" node (or a predicate function or a wildcard); if you are working on a repeater chain, a good choice is `<(current_node)`, i.e. any node to the "left" of the current node"""
     nodeL::NL = ❓
     """the vertex of the other remote node for the swap, the "high" counterpart of `nodeL`; if you are working on a repeater chain, a good choice is `>(current_node)`, i.e. any node to the "right" of the current node"""
-    nodeH::NH = ❓ # TODO consider changing the default to random
+    nodeH::NH = ❓
     """the `nodeL` predicate can return many positive candidates; `chooseL` picks one of them (by index into the array of filtered `nodeL` results), defaults to a random pick `arr->rand(keys(arr))`; if you are working on a repeater chain a good choice is `argmin`, i.e. the node furthest to the "left" """
     chooseL::CL = random_index
     """the `nodeH` counterpart for `chooseH`; if you are working on a repeater chain a good choice is `argmax`, i.e. the node furthest to the "right" """
@@ -219,7 +219,7 @@ end
     end
 end
 
-function findswapablequbits(net, node, pred_low, pred_high, choose_low, choose_high) # TODO parameterize the query predicates and the findmin/findmax
+function findswapablequbits(net, node, pred_low, pred_high, choose_low, choose_high)
     reg = net[node]
 
     low_nodes  = queryall(reg, EntanglementCounterpart, pred_low, ❓; locked=false, assigned=true)

--- a/src/queries.jl
+++ b/src/queries.jl
@@ -257,8 +257,8 @@ for (tagsymbol, tagvariant) in pairs(tag_types)
         sig_wild = collect(sig)
         sig_wild[idx] .= Union{Wildcard,Function}
         argssig_wild = [:($a::$t) for (a,t) in zip(args, sig_wild)]
-        wild_checks = [:(isa($(args[i]),Wildcard) || $(args[i])(tag.data[$i])) for i in idx]
-        nonwild_checks = [:(tag.data[$i]==$(args[i])) for i in complement_idx]
+        wild_checks = [:(isa($(args[i]),Wildcard) || $(args[i])(tag[$i])) for i in idx]
+        nonwild_checks = [:(tag[$i]==$(args[i])) for i in complement_idx]
         newmethod_reg = quote function query(reg::Register, $(argssig_wild...), ::Val{allB}=Val{false}(); locked::Union{Nothing,Bool}=nothing, assigned::Union{Nothing,Bool}=nothing) where {allB}
             res = NamedTuple{(:slot, :tag), Tuple{RegRef, Tag}}[]
             for (reg_idx, tags) in enumerate(reg.tags)

--- a/src/tags.jl
+++ b/src/tags.jl
@@ -24,9 +24,9 @@ end
 See also: [`query`](@ref), [`tag!`](@ref), [`Wildcard`](@ref)"""
 const tag_types = Tag'
 
-Base.getindex(tag::Tag, i::Int) = tag.data[i]
-Base.length(tag::Tag) = length(tag.data.data)
-Base.iterate(tag::Tag, state=1) = state > length(tag) ? nothing : (tag[state],state+1)
+Base.getindex(tag::Tag, i::Int) = SumTypes.unwrap(tag)[i]
+Base.length(tag::Tag) = length(SumTypes.unwrap(tag).data)
+Base.iterate(tag::Tag, state=1) = state > length(tag) ? nothing : (SumTypes.unwrap(tag)[state],state+1)
 
 function SumTypes.show_sumtype(io::IO, x::Tag)
     data = SumTypes.unwrap(x)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -32,6 +32,7 @@ println("Starting tests with $(Threads.nthreads()) threads out of `Sys.CPU_THREA
 @doset "messagebuffer"
 @doset "tags_and_queries"
 @doset "entanglement_tracker"
+@doset "entanglement_tracker_grid"
 
 @doset "circuitzoo_api"
 @doset "circuitzoo_ent_swap"

--- a/test/test_entanglement_tracker.jl
+++ b/test/test_entanglement_tracker.jl
@@ -46,8 +46,8 @@ for i in 1:10
     @test [islocked(ref) for i in vertices(net) for ref in net[i]] |> any == false
 
 
-    swapper2 = SwapperProt(sim, net, 2; rounds=1)
-    swapper3 = SwapperProt(sim, net, 3; rounds=1)
+    swapper2 = SwapperProt(sim, net, 2; nodeL = <(2), nodeH = >(2), rounds = 1)
+    swapper3 = SwapperProt(sim, net, 3; nodeL = <(3), nodeH = >(3), rounds = 1)
     @process swapper2()
     @process swapper3()
     run(sim, 80)
@@ -102,7 +102,7 @@ for i in 1:30, n in 2:30
         @process eprot()
     end
     for j in 2:n-1
-        swapper = SwapperProt(sim, net, j; rounds=1)
+        swapper = SwapperProt(sim, net, j; nodeL = <(j), nodeH = >(j), rounds = 1)
         @process swapper()
     end
     run(sim, 200)
@@ -110,139 +110,6 @@ for i in 1:30, n in 2:30
     q1 = query(net[1], EntanglementCounterpart, n, ❓)
     q2 = query(net[n], EntanglementCounterpart, 1, ❓)
     @test q1.tag[2] == n
-    @test q2.tag[2] == 1
-    @test observable((q1.slot, q2.slot), Z⊗Z) ≈ 1
-    @test observable((q1.slot, q2.slot), X⊗X) ≈ 1
-end
-
-
-# Tests with 2d Grid
-
-## Custom Predicates
-function top_left(net, node, x)
-    n = sqrt(size(net.graph)[1]) # grid size
-    a = (node ÷ n) + 1 # row number
-    for i in 1:a-1
-        if x == (i-1)*n + i
-            return true
-        end
-    end
-    return false
-end
-
-function bottom_right(net, node, x)
-    n = sqrt(size(net.graph)[1]) # grid size
-    a = (node ÷ n) + 1 # row number
-    for i in a+1:n
-        if x == (i-1)*n + i
-            return true
-        end
-    end
-    return false
-end
-
-## Simulation
-
-#without entanglement tracker
-for i in 1:10
-    graph = grid([4, 4])
-    add_edge!(graph, 1, 6)
-    add_edge!(graph, 6, 11)
-    add_edge!(graph, 11, 16)
-    
-    net = RegisterNet(graph, [Register(3) for i in 1:16])
-    sim = get_time_tracker(net)
-
-
-    entangler1 = EntanglerProt(sim, net, 1, 6; rounds=1)
-    @process entangler1()
-    run(sim, 20)
-
-    @test net[1].tags == [[Tag(EntanglementCounterpart, 6, 1)],[],[]]
-
-
-    entangler2 = EntanglerProt(sim, net, 6, 11; rounds=1)
-    @process entangler2()
-    run(sim, 40)
-    entangler3 = EntanglerProt(sim, net, 11, 16; rounds=1)
-    @process entangler3()
-    run(sim, 60)
-
-    @test net[1].tags == [[Tag(EntanglementCounterpart, 6, 1)],[],[]]
-    @test net[6].tags == [[Tag(EntanglementCounterpart, 1, 1)],[Tag(EntanglementCounterpart, 11, 1)],[]]
-    @test net[11].tags == [[Tag(EntanglementCounterpart, 6, 2)],[Tag(EntanglementCounterpart, 16, 1)], []]
-    @test net[16].tags == [[Tag(EntanglementCounterpart, 11, 2)],[],[]]
-
-    @test [islocked(ref) for i in vertices(net) for ref in net[i]] |> any == false
-
-    l1(x) = top_left(net, 6, x)
-    h1(x) = bottom_right(net, 6, x)
-    swapper2 = SwapperProt(sim, net, 6; nodeL=l1, nodeR=h1, rounds=1)
-    l2(x) = top_left(net, 11, x)
-    h2(x) = bottom_right(net, 11, x)
-    swapper3 = SwapperProt(sim, net, 11; nodeL=l2, nodeR=h2, rounds=1)
-    @process swapper2()
-    @process swapper3()
-    run(sim, 80)
-
-    # In the absence of an entanglement tracker the tags will not all be updated
-    @test net[1].tags == [[Tag(EntanglementCounterpart, 6, 1)],[],[]]
-    @test net[6].tags == [[Tag(EntanglementHistory, 1, 1, 11, 1, 2)],[Tag(EntanglementHistory, 11, 1, 1, 1, 1)],[]]
-    @test net[11].tags == [[Tag(EntanglementHistory, 6, 2, 16, 1, 2)],[Tag(EntanglementHistory, 16, 1, 6, 2, 1)], []]
-    @test net[16].tags == [[Tag(EntanglementCounterpart, 11, 2)],[],[]]
-
-    @test isassigned(net[1][1]) && isassigned(net[16][1])
-    @test !isassigned(net[6][1]) && !isassigned(net[11][1])
-    @test !isassigned(net[6][2]) && !isassigned(net[11][2])
-
-    @test [islocked(ref) for i in vertices(net) for ref in net[i]] |> any == false
-
-end
-
-# with entanglement tracker
-for n in 4:10
-    graph = grid([n,n])
-    
-    diag_pairs = []
-    diag_nodes = []
-    reg_num = 1 # starting register
-    for i in 1:n-1 # a grid with n nodes has n-1 pairs of diagonal nodes
-        push!(diag_pairs, (reg_num, reg_num+n+1))
-        push!(diag_nodes, reg_num)
-        reg_num += n + 1
-    end
-    push!(diag_nodes, n^2)
-
-    for (src, dst) in diag_pairs # need edges down the diagonal to establish cchannels and qchannels between the diagonal nodes
-        add_edge!(graph, src, dst)
-    end
-
-    net = RegisterNet(graph, [Register(8) for i in 1:n^2])
-
-    sim = get_time_tracker(net)
-
-    for (src, dst) in diag_pairs
-        eprot = EntanglerProt(sim, net, src, dst; rounds=1, randomize=true)
-        @process eprot()
-    end
-
-    for i in 2:n-1
-        l(x) = top_left(net, diag_nodes[i], x)
-        h(x) = bottom_right(net, diag_nodes[i], x)
-        swapper = SwapperProt(sim, net, diag_nodes[i]; nodeL = l, nodeR = h, rounds = 1)
-        @process swapper()
-    end
-
-    for v in diag_nodes
-        tracker = EntanglementTracker(sim, net, v)
-        @process tracker()
-    end
-
-    run(sim, 200)
-
-    q1 = query(net[1], EntanglementCounterpart, diag_nodes[n], ❓)
-    q2 = query(net[diag_nodes[n]], EntanglementCounterpart, 1, ❓)
-    @test q1.tag[2] == diag_nodes[n]
     @test q2.tag[2] == 1
     @test observable((q1.slot, q2.slot), Z⊗Z) ≈ 1
     @test observable((q1.slot, q2.slot), X⊗X) ≈ 1

--- a/test/test_entanglement_tracker.jl
+++ b/test/test_entanglement_tracker.jl
@@ -46,8 +46,8 @@ for i in 1:10
     @test [islocked(ref) for i in vertices(net) for ref in net[i]] |> any == false
 
 
-    swapper2 = SwapperProt(sim, net, 2; nodeL = <(2), nodeH = >(2), rounds = 1)
-    swapper3 = SwapperProt(sim, net, 3; nodeL = <(3), nodeH = >(3), rounds = 1)
+    swapper2 = SwapperProt(sim, net, 2; nodeL = <(2), nodeH = >(2), chooseL = argmin, chooseH = argmax, rounds = 1)
+    swapper3 = SwapperProt(sim, net, 3; nodeL = <(3), nodeH = >(3), chooseL = argmin, chooseH = argmax, rounds = 1)
     @process swapper2()
     @process swapper3()
     run(sim, 80)
@@ -102,7 +102,7 @@ for i in 1:30, n in 2:30
         @process eprot()
     end
     for j in 2:n-1
-        swapper = SwapperProt(sim, net, j; nodeL = <(j), nodeH = >(j), rounds = 1)
+        swapper = SwapperProt(sim, net, j; nodeL = <(j), nodeH = >(j), chooseL = argmin, chooseH = argmax, rounds = 1)
         @process swapper()
     end
     run(sim, 200)

--- a/test/test_entanglement_tracker.jl
+++ b/test/test_entanglement_tracker.jl
@@ -114,3 +114,143 @@ for i in 1:30, n in 2:30
     @test observable((q1.slot, q2.slot), Z⊗Z) ≈ 1
     @test observable((q1.slot, q2.slot), X⊗X) ≈ 1
 end
+
+
+# Tests with 2d Grid
+
+using Revise
+using QuantumSavory
+using QuantumSavory.ProtocolZoo: EntanglerProt, SwapperProt, EntanglementTracker
+using Graphs
+using Test
+using ResumableFunctions
+using ConcurrentSim
+
+using Logging
+logger = ConsoleLogger(Logging.Debug; meta_formatter=(args...)->(:black, "", ""))
+global_logger(logger)
+
+## Custom Predicates
+function top_left(net, node, x)
+    n = sqrt(size(net.graph)[1]) # grid size
+    a = (node ÷ n) + 1 # row number
+    for i in 1:a-1
+        if x == (i-1)*n + i
+            return true
+        end
+    end
+    return false
+end
+
+function bottom_right(net, node, x)
+    n = sqrt(size(net.graph)[1]) # grid size
+    a = (node ÷ n) + 1 # row number
+    for i in a+1:n
+        if x == (i-1)*n + i
+            return true
+        end
+    end
+    return false
+end
+
+## Simulation
+
+#without entanglement tracker
+for i in 1:10
+    graph = grid([4, 4])
+    add_edge!(graph, 1, 6)
+    add_edge!(graph, 6, 11)
+    add_edge!(graph, 11, 16)
+    
+    net = RegisterNet(graph, [Register(3) for i in 1:16])
+    sim = get_time_tracker(net)
+
+
+    entangler1 = EntanglerProt(sim, net, 1, 6; rounds=1)
+    @process entangler1()
+    run(sim, 20)
+
+    @test net[1].tags == [[Tag(EntanglementCounterpart, 6, 1)],[],[]]
+
+
+    entangler2 = EntanglerProt(sim, net, 6, 11; rounds=1)
+    @process entangler2()
+    run(sim, 40)
+    entangler3 = EntanglerProt(sim, net, 11, 16; rounds=1)
+    @process entangler3()
+    run(sim, 60)
+
+    @test net[1].tags == [[Tag(EntanglementCounterpart, 6, 1)],[],[]]
+    @test net[6].tags == [[Tag(EntanglementCounterpart, 1, 1)],[Tag(EntanglementCounterpart, 11, 1)],[]]
+    @test net[11].tags == [[Tag(EntanglementCounterpart, 6, 2)],[Tag(EntanglementCounterpart, 16, 1)], []]
+    @test net[16].tags == [[Tag(EntanglementCounterpart, 11, 2)],[],[]]
+
+    @test [islocked(ref) for i in vertices(net) for ref in net[i]] |> any == false
+
+
+    swapper2 = SwapperProt(sim, net, 6; nodeL=top_left, nodeR=bottom_right, rounds=1)
+    swapper3 = SwapperProt(sim, net, 11; nodeL=top_left, nodeR=bottom_right, rounds=1)
+    @process swapper2()
+    @process swapper3()
+    run(sim, 80)
+
+    # In the absence of an entanglement tracker the tags will not all be updated
+    @test net[1].tags == [[Tag(EntanglementCounterpart, 6, 1)],[],[]]
+    @test net[6].tags == [[Tag(EntanglementHistory, 1, 1, 11, 1, 2)],[Tag(EntanglementHistory, 11, 1, 1, 1, 1)],[]]
+    @test net[11].tags == [[Tag(EntanglementHistory, 6, 2, 16, 1, 2)],[Tag(EntanglementHistory, 16, 1, 6, 2, 1)], []]
+    @test net[16].tags == [[Tag(EntanglementCounterpart, 11, 2)],[],[]]
+
+    @test isassigned(net[1][1]) && isassigned(net[16][1])
+    @test !isassigned(net[6][1]) && !isassigned(net[11][1])
+    @test !isassigned(net[6][2]) && !isassigned(net[11][2])
+
+    @test [islocked(ref) for i in vertices(net) for ref in net[i]] |> any == false
+
+end
+
+# with entanglement tracker
+for n in 4:10
+    graph = grid([n,n])
+    
+    diag_pairs = []
+    diag_nodes = []
+    reg_num = 1 # starting register
+    for i in 1:n-1 # a grid with n nodes has n-1 pairs of diagonal nodes
+        push!(diag_pairs, (reg_num, reg_num+n+1))
+        push!(diag_nodes, reg_num)
+        reg_num += n + 1
+    end
+    push!(diag_nodes, n^2)
+
+    for (src, dst) in diag_pairs # need edges down the diagonal to establish cchannels and qchannels between the diagonal nodes
+        add_edge!(graph, src, dst)
+    end
+
+    net = RegisterNet(graph, [Register(8) for i in 1:n^2])
+
+    sim = get_time_tracker(net)
+
+    for (src, dst) in diag_pairs
+        eprot = EntanglerProt(sim, net, src, dst; rounds=1, randomize=true)
+        @process eprot()
+    end
+
+    for i in 2:n-1
+        swapper = SwapperProt(sim, net, diag_nodes[i]; nodeL = top_left, nodeR = bottom_right, rounds = 1)
+        @process swapper()
+    end
+
+    for v in diag_nodes
+        tracker = EntanglementTracker(sim, net, v)
+        @process tracker()
+    end
+
+    run(sim, 200)
+
+    q1 = query(net[1], EntanglementCounterpart, diag_nodes[n], ❓)
+    q2 = query(net[diag_nodes[n]], EntanglementCounterpart, 1, ❓)
+    @test q1.tag[2] == diag_nodes[n]
+    @test q2.tag[2] == 1
+    @test observable((q1.slot, q2.slot), Z⊗Z) ≈ 1
+    @test observable((q1.slot, q2.slot), X⊗X) ≈ 1
+end

--- a/test/test_entanglement_tracker.jl
+++ b/test/test_entanglement_tracker.jl
@@ -46,8 +46,8 @@ for i in 1:10
     @test [islocked(ref) for i in vertices(net) for ref in net[i]] |> any == false
 
 
-    swapper2 = SwapperProt(sim, net, 2; nodeL = <(2), nodeH = >(2), chooseL = argmin, chooseH = argmax, rounds = 1)
-    swapper3 = SwapperProt(sim, net, 3; nodeL = <(3), nodeH = >(3), chooseL = argmin, chooseH = argmax, rounds = 1)
+    swapper2 = SwapperProt(sim, net, 2; nodeL = <(2), nodeH = >(2), chooseL = findmin, chooseH = findmax, rounds = 1)
+    swapper3 = SwapperProt(sim, net, 3; nodeL = <(3), nodeH = >(3), chooseL = findmin, chooseH = findmax, rounds = 1)
     @process swapper2()
     @process swapper3()
     run(sim, 80)
@@ -102,7 +102,7 @@ for i in 1:30, n in 2:30
         @process eprot()
     end
     for j in 2:n-1
-        swapper = SwapperProt(sim, net, j; nodeL = <(j), nodeH = >(j), chooseL = argmin, chooseH = argmax, rounds = 1)
+        swapper = SwapperProt(sim, net, j; nodeL = <(j), nodeH = >(j), chooseL = findmin, chooseH = findmax, rounds = 1)
         @process swapper()
     end
     run(sim, 200)

--- a/test/test_entanglement_tracker.jl
+++ b/test/test_entanglement_tracker.jl
@@ -118,18 +118,6 @@ end
 
 # Tests with 2d Grid
 
-using Revise
-using QuantumSavory
-using QuantumSavory.ProtocolZoo: EntanglerProt, SwapperProt, EntanglementTracker
-using Graphs
-using Test
-using ResumableFunctions
-using ConcurrentSim
-
-using Logging
-logger = ConsoleLogger(Logging.Debug; meta_formatter=(args...)->(:black, "", ""))
-global_logger(logger)
-
 ## Custom Predicates
 function top_left(net, node, x)
     n = sqrt(size(net.graph)[1]) # grid size

--- a/test/test_entanglement_tracker.jl
+++ b/test/test_entanglement_tracker.jl
@@ -18,7 +18,7 @@ end
 
 # without an entanglement tracker
 
-# for i in 1:10
+for i in 1:10
 
     net = RegisterNet([Register(3), Register(4), Register(2), Register(3)])
     sim = get_time_tracker(net)
@@ -64,7 +64,7 @@ end
 
     @test [islocked(ref) for i in vertices(net) for ref in net[i]] |> any == false
 
-# end
+end
 
 ##
 

--- a/test/test_entanglement_tracker.jl
+++ b/test/test_entanglement_tracker.jl
@@ -18,7 +18,7 @@ end
 
 # without an entanglement tracker
 
-for i in 1:10
+# for i in 1:10
 
     net = RegisterNet([Register(3), Register(4), Register(2), Register(3)])
     sim = get_time_tracker(net)
@@ -46,8 +46,8 @@ for i in 1:10
     @test [islocked(ref) for i in vertices(net) for ref in net[i]] |> any == false
 
 
-    swapper2 = SwapperProt(sim, net, 2; nodeL = <(2), nodeH = >(2), chooseL = findmin, chooseH = findmax, rounds = 1)
-    swapper3 = SwapperProt(sim, net, 3; nodeL = <(3), nodeH = >(3), chooseL = findmin, chooseH = findmax, rounds = 1)
+    swapper2 = SwapperProt(sim, net, 2; nodeL = <(2), nodeH = >(2), chooseL = argmin, chooseH = argmax, rounds = 1)
+    swapper3 = SwapperProt(sim, net, 3; nodeL = <(3), nodeH = >(3), chooseL = argmin, chooseH = argmax, rounds = 1)
     @process swapper2()
     @process swapper3()
     run(sim, 80)
@@ -64,7 +64,7 @@ for i in 1:10
 
     @test [islocked(ref) for i in vertices(net) for ref in net[i]] |> any == false
 
-end
+# end
 
 ##
 
@@ -102,7 +102,7 @@ for i in 1:30, n in 2:30
         @process eprot()
     end
     for j in 2:n-1
-        swapper = SwapperProt(sim, net, j; nodeL = <(j), nodeH = >(j), chooseL = findmin, chooseH = findmax, rounds = 1)
+        swapper = SwapperProt(sim, net, j; nodeL = <(j), nodeH = >(j), chooseL = argmin, chooseH = argmax, rounds = 1)
         @process swapper()
     end
     run(sim, 200)

--- a/test/test_entanglement_tracker.jl
+++ b/test/test_entanglement_tracker.jl
@@ -175,9 +175,12 @@ for i in 1:10
 
     @test [islocked(ref) for i in vertices(net) for ref in net[i]] |> any == false
 
-
-    swapper2 = SwapperProt(sim, net, 6; nodeL=top_left, nodeR=bottom_right, rounds=1)
-    swapper3 = SwapperProt(sim, net, 11; nodeL=top_left, nodeR=bottom_right, rounds=1)
+    l1(x) = top_left(net, 6, x)
+    h1(x) = bottom_right(net, 6, x)
+    swapper2 = SwapperProt(sim, net, 6; nodeL=l1, nodeR=h1, rounds=1)
+    l2(x) = top_left(net, 11, x)
+    h2(x) = bottom_right(net, 11, x)
+    swapper3 = SwapperProt(sim, net, 11; nodeL=l2, nodeR=h2, rounds=1)
     @process swapper2()
     @process swapper3()
     run(sim, 80)
@@ -224,7 +227,9 @@ for n in 4:10
     end
 
     for i in 2:n-1
-        swapper = SwapperProt(sim, net, diag_nodes[i]; nodeL = top_left, nodeR = bottom_right, rounds = 1)
+        l(x) = top_left(net, diag_nodes[i], x)
+        h(x) = bottom_right(net, diag_nodes[i], x)
+        swapper = SwapperProt(sim, net, diag_nodes[i]; nodeL = l, nodeR = h, rounds = 1)
         @process swapper()
     end
 

--- a/test/test_entanglement_tracker_grid.jl
+++ b/test/test_entanglement_tracker_grid.jl
@@ -14,7 +14,13 @@ if isinteractive()
     println("Logger set to debug")
 end
 
+##
+# Here we test entanglement tracker and swapper protocols on an arbitrary hardcoded path of long-range connection inside of what is otherwise a 2D grid
+# We do NOT test anything related to automatic routing on such a grid -- only the hardcoded path is tested
+##
+
 ## Custom Predicates
+
 function top_left(net, node, x)
     n = sqrt(size(net.graph)[1]) # grid size
     a = (node ÷ n) + 1 # row number
@@ -39,13 +45,13 @@ end
 
 ## Simulation
 
-#without entanglement tracker
+## without entanglement tracker - this is almost the same test as the one in test_entanglement_tracker.jl which tests a simple chain -- the only difference is that we have picked a few hardcoded arbitrary nodes through a grid (creating an ad-hoc chain)
 for i in 1:10
     graph = grid([4, 4])
     add_edge!(graph, 1, 6)
     add_edge!(graph, 6, 11)
     add_edge!(graph, 11, 16)
-    
+
     net = RegisterNet(graph, [Register(3) for i in 1:16])
     sim = get_time_tracker(net)
 
@@ -95,10 +101,10 @@ for i in 1:10
 
 end
 
-# with entanglement tracker
+## with entanglement tracker -- here we hardcode the diagonal of the grid as the path on which we are making connections
 for n in 4:10
     graph = grid([n,n])
-    
+
     diag_pairs = []
     diag_nodes = []
     reg_num = 1 # starting register

--- a/test/test_entanglement_tracker_grid.jl
+++ b/test/test_entanglement_tracker_grid.jl
@@ -1,0 +1,145 @@
+using Revise
+using QuantumSavory
+using ResumableFunctions
+using ConcurrentSim
+using QuantumSavory.ProtocolZoo
+using QuantumSavory.ProtocolZoo: EntanglementCounterpart, EntanglementHistory, EntanglementUpdateX, EntanglementUpdateZ
+using Graphs
+using Test
+
+if isinteractive()
+    using Logging
+    logger = ConsoleLogger(Logging.Debug; meta_formatter=(args...)->(:black,"",""))
+    global_logger(logger)
+    println("Logger set to debug")
+end
+
+## Custom Predicates
+function top_left(net, node, x)
+    n = sqrt(size(net.graph)[1]) # grid size
+    a = (node ÷ n) + 1 # row number
+    for i in 1:a-1
+        if x == (i-1)*n + i
+            return true
+        end
+    end
+    return false
+end
+
+function bottom_right(net, node, x)
+    n = sqrt(size(net.graph)[1]) # grid size
+    a = (node ÷ n) + 1 # row number
+    for i in a+1:n
+        if x == (i-1)*n + i
+            return true
+        end
+    end
+    return false
+end
+
+## Simulation
+
+#without entanglement tracker
+for i in 1:10
+    graph = grid([4, 4])
+    add_edge!(graph, 1, 6)
+    add_edge!(graph, 6, 11)
+    add_edge!(graph, 11, 16)
+    
+    net = RegisterNet(graph, [Register(3) for i in 1:16])
+    sim = get_time_tracker(net)
+
+
+    entangler1 = EntanglerProt(sim, net, 1, 6; rounds=1)
+    @process entangler1()
+    run(sim, 20)
+
+    @test net[1].tags == [[Tag(EntanglementCounterpart, 6, 1)],[],[]]
+
+
+    entangler2 = EntanglerProt(sim, net, 6, 11; rounds=1)
+    @process entangler2()
+    run(sim, 40)
+    entangler3 = EntanglerProt(sim, net, 11, 16; rounds=1)
+    @process entangler3()
+    run(sim, 60)
+
+    @test net[1].tags == [[Tag(EntanglementCounterpart, 6, 1)],[],[]]
+    @test net[6].tags == [[Tag(EntanglementCounterpart, 1, 1)],[Tag(EntanglementCounterpart, 11, 1)],[]]
+    @test net[11].tags == [[Tag(EntanglementCounterpart, 6, 2)],[Tag(EntanglementCounterpart, 16, 1)], []]
+    @test net[16].tags == [[Tag(EntanglementCounterpart, 11, 2)],[],[]]
+
+    @test [islocked(ref) for i in vertices(net) for ref in net[i]] |> any == false
+
+    l1(x) = top_left(net, 6, x)
+    h1(x) = bottom_right(net, 6, x)
+    swapper2 = SwapperProt(sim, net, 6; nodeL=l1, nodeH=h1, rounds=1)
+    l2(x) = top_left(net, 11, x)
+    h2(x) = bottom_right(net, 11, x)
+    swapper3 = SwapperProt(sim, net, 11; nodeL=l2, nodeH=h2, rounds=1)
+    @process swapper2()
+    @process swapper3()
+    run(sim, 80)
+
+    # In the absence of an entanglement tracker the tags will not all be updated
+    @test net[1].tags == [[Tag(EntanglementCounterpart, 6, 1)],[],[]]
+    @test net[6].tags == [[Tag(EntanglementHistory, 1, 1, 11, 1, 2)],[Tag(EntanglementHistory, 11, 1, 1, 1, 1)],[]]
+    @test net[11].tags == [[Tag(EntanglementHistory, 6, 2, 16, 1, 2)],[Tag(EntanglementHistory, 16, 1, 6, 2, 1)], []]
+    @test net[16].tags == [[Tag(EntanglementCounterpart, 11, 2)],[],[]]
+
+    @test isassigned(net[1][1]) && isassigned(net[16][1])
+    @test !isassigned(net[6][1]) && !isassigned(net[11][1])
+    @test !isassigned(net[6][2]) && !isassigned(net[11][2])
+
+    @test [islocked(ref) for i in vertices(net) for ref in net[i]] |> any == false
+
+end
+
+# with entanglement tracker
+for n in 4:10
+    graph = grid([n,n])
+    
+    diag_pairs = []
+    diag_nodes = []
+    reg_num = 1 # starting register
+    for i in 1:n-1 # a grid with n nodes has n-1 pairs of diagonal nodes
+        push!(diag_pairs, (reg_num, reg_num+n+1))
+        push!(diag_nodes, reg_num)
+        reg_num += n + 1
+    end
+    push!(diag_nodes, n^2)
+
+    for (src, dst) in diag_pairs # need edges down the diagonal to establish cchannels and qchannels between the diagonal nodes
+        add_edge!(graph, src, dst)
+    end
+
+    net = RegisterNet(graph, [Register(8) for i in 1:n^2])
+
+    sim = get_time_tracker(net)
+
+    for (src, dst) in diag_pairs
+        eprot = EntanglerProt(sim, net, src, dst; rounds=1, randomize=true)
+        @process eprot()
+    end
+
+    for i in 2:n-1
+        l(x) = top_left(net, diag_nodes[i], x)
+        h(x) = bottom_right(net, diag_nodes[i], x)
+        swapper = SwapperProt(sim, net, diag_nodes[i]; nodeL = l, nodeH = h, rounds = 1)
+        @process swapper()
+    end
+
+    for v in diag_nodes
+        tracker = EntanglementTracker(sim, net, v)
+        @process tracker()
+    end
+
+    run(sim, 200)
+
+    q1 = query(net[1], EntanglementCounterpart, diag_nodes[n], ❓)
+    q2 = query(net[diag_nodes[n]], EntanglementCounterpart, 1, ❓)
+    @test q1.tag[2] == diag_nodes[n]
+    @test q2.tag[2] == 1
+    @test observable((q1.slot, q2.slot), Z⊗Z) ≈ 1
+    @test observable((q1.slot, q2.slot), X⊗X) ≈ 1
+end


### PR DESCRIPTION
Following #85, here, an entanglement simulation  is implemented on a grid that runs `EntanglerProt` and `SwapperProt` only on the diagonal