### PR TITLE
simplify the `query` implementation

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@latest
         with:
-          version: 'nightly'
+          version: '1'
       - uses: julia-actions/julia-buildpkg@latest
       - name: install dependencies
         run: julia -e 'using Pkg; pkg"add PkgBenchmark BenchmarkCI@0.1"'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,14 @@
 # News
 
+## v0.4.1 - 2024-06-05
+
+- Significant improvements to the performance of `query`.
+
 ## v0.4.0 - 2024-06-03
 
 - Establishing `ProtocolZoo`, `CircuitZoo`, and `StateZoo`
 - Establishing `Register`, `RegRef`, and `RegisterNet`
 - Establishing the symbolic expression capabilities
 - Establishing plotting and visualization capabilities
+
+## older versions were not tracked

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "QuantumSavory"
 uuid = "2de2e421-972c-4cb5-a0c3-999c85908079"
 authors = ["Stefan Krastanov <stefan@krastanov.org>"]
-version = "0.4.0"
+version = "0.4.1"
 
 [deps]
 Cbc = "9961bab8-2fa3-5c5a-9d89-47fab24efd76"

--- a/docs/src/tag_query.md
+++ b/docs/src/tag_query.md
@@ -46,9 +46,7 @@ One can also query by "lock" and "assignment" status of a given slot, by using t
 Following is a detailed description of each `query` method
 
 ```@docs; canonical=false
-query(::Register,::Tag)
-query(::RegRef,::Tag) 
-query(::MessageBuffer,::Tag)
+query
 ```
 
 ### Wildcards
@@ -63,8 +61,7 @@ W
 A method on top of [`query`](@ref), which allows to query for tag in a [`RegRef`](@ref) or a [`messagebuffer`](@ref), returning the tag that satisfies the passed predicates and wildcars, **and deleting it from the list at the same time**. It otherwise has the same signature as [`query`](@ref).
 
 ```@docs; canonical=false
-querydelete!(::RegRef)
-querydelete!(::MessageBuffer)
+querydelete!
 ```
 
 ### `queryall`

--- a/src/messagebuffer.jl
+++ b/src/messagebuffer.jl
@@ -30,6 +30,8 @@ function Base.put!(mb::MessageBuffer, tag)
     nothing
 end
 
+tag!(::MessageBuffer, args...) = throw(ArgumentError("MessageBuffer does not support `tag!`. Use `put!(::MessageBuffer, Tag(...))` instead."))
+
 function Base.put!(reg::Register, tag)
     put!(messagebuffer(reg), tag)
 end

--- a/src/tags.jl
+++ b/src/tags.jl
@@ -45,7 +45,7 @@ end
 See also: [`query`](@ref), [`tag!`](@ref), [`Wildcard`](@ref)"""
 const tag_types = Tag'
 
-Base.getindex(tag::Tag, i::Int) = SumTypes.unwrap(tag)[i]
+Base.@propagate_inbounds Base.getindex(tag::Tag, i::Int) = SumTypes.unwrap(tag).data[i]
 Base.length(tag::Tag) = length(SumTypes.unwrap(tag).data)
 Base.iterate(tag::Tag, state=1) = state > length(tag) ? nothing : (SumTypes.unwrap(tag)[state],state+1)
 

--- a/src/tags.jl
+++ b/src/tags.jl
@@ -65,3 +65,13 @@ end
 
 Base.convert(::Type{Tag}, x::Tag) = x
 Base.convert(::Type{Tag}, x) = Tag(x)
+
+# Create a constructor for each tag variant
+for (tagsymbol, tagvariant) in pairs(tag_types)
+    sig = methods(tagvariant)[1].sig.parameters[2:end]
+    args = (:a, :b, :c, :d, :e, :f, :g)[1:length(sig)]
+    argssig = [:($a::$t) for (a,t) in zip(args, sig)]
+    eval(quote function Tag($(argssig...))
+        ($tagvariant)($(args...))
+    end end)
+end

--- a/src/tags.jl
+++ b/src/tags.jl
@@ -1,3 +1,5 @@
+const TagElementTypes = Union{Symbol, Int, DataType}
+
 """
 Tags are used to represent classical metadata describing the state (or even history) of nodes and their registers. The library allows the construction of custom tags using the `Tag` constructor. Currently tags are implemented as instances of a [sum type](https://github.com/MasonProtter/SumTypes.jl) and have fairly constrained structure. Most of them are constrained to contain only Symbol instances and integers.
 

--- a/test/test_messagebuffer.jl
+++ b/test/test_messagebuffer.jl
@@ -41,3 +41,4 @@ proc3 = put!(messagebuffer(net[1]), Tag(SwitchRequest(2,3)))
 proc4 = put!(messagebuffer(net[1]), SwitchRequest(2,3))
 run(sim, 10)
 @test QuantumSavory.peektags(messagebuffer(net,1)) == [Tag(SwitchRequest(2,3)), Tag(SwitchRequest(2,3)), Tag(SwitchRequest(2,3)), Tag(SwitchRequest(2,3))]
+@test_throws "does not support `tag!`" tag!(messagebuffer(net, 1), EntanglementCounterpart, 1, 10)

--- a/test/test_tags_and_queries.jl
+++ b/test/test_tags_and_queries.jl
@@ -58,15 +58,15 @@ tag!(reg[3], EntanglementCounterpart, 1, 10)
 
 @test query(reg[3], EntanglementCounterpart, 1, 11) === nothing
 @test strip_id(query(reg[3], EntanglementCounterpart, 1, 10)) == (slot = reg[3], tag = Tag(EntanglementCounterpart,1,10))
-@test strip_id(query(reg[3], EntanglementCounterpart, 1, 10, Val(false); filo=false)) == (slot = reg[3], tag = Tag(EntanglementCounterpart,1,10))
-@test strip_id(query(reg[3], EntanglementCounterpart, 1, 10, Val(false); filo=true)) == (slot = reg[3], tag = Tag(EntanglementCounterpart,1,10))
+@test strip_id(query(reg[3], EntanglementCounterpart, 1, 10; filo=false)) == (slot = reg[3], tag = Tag(EntanglementCounterpart,1,10))
+@test strip_id(query(reg[3], EntanglementCounterpart, 1, 10; filo=true)) == (slot = reg[3], tag = Tag(EntanglementCounterpart,1,10))
 @test query(reg[3], EntanglementCounterpart, 1, 10; filo=true).id > query(reg[3], EntanglementCounterpart, 1, 10; filo=false).id
 @test query(reg[3], EntanglementCounterpart, 2, ❓; filo=true).tag[3] == 23
 @test query(reg[3], EntanglementCounterpart, 2, ❓; filo=false).tag[3] == 21
 
 @test strip_id(query(reg[3], EntanglementCounterpart, 2, ❓)) == (slot = reg[3], tag = Tag(EntanglementCounterpart,2,23))
-@test strip_id(query(reg[3], EntanglementCounterpart, 2, ❓, Val(false); filo=false)) == (slot = reg[3], tag = Tag(EntanglementCounterpart,2,21))
-@test strip_id(query(reg[3], EntanglementCounterpart, 2, ❓, Val(false); filo=true)) == (slot = reg[3], tag = Tag(EntanglementCounterpart,2,23))
+@test strip_id(query(reg[3], EntanglementCounterpart, 2, ❓; filo=false)) == (slot = reg[3], tag = Tag(EntanglementCounterpart,2,21))
+@test strip_id(query(reg[3], EntanglementCounterpart, 2, ❓; filo=true)) == (slot = reg[3], tag = Tag(EntanglementCounterpart,2,23))
 
 @test queryall(reg, EntanglementCounterpart, 1, 11) == []
 default_ids = [r.id for r in queryall(reg[3], EntanglementCounterpart, 1, 10)]
@@ -97,12 +97,12 @@ end
 @test query(reg, EntanglementCounterpart, 1, 12) == query(reg, EntanglementCounterpart, ==(1), ==(12))
 @test query(reg, Tag(EntanglementCounterpart, 1, 10)) === nothing
 @test strip_id(query(reg, Tag(EntanglementCounterpart, 1, 12))) == (slot = reg[2], tag = Tag(EntanglementCounterpart,1,12))
-@test strip_id(query(reg, EntanglementCounterpart, 1, 12, Val(false); filo=false)) == (slot = reg[2], tag = Tag(EntanglementCounterpart,1,12))
-@test strip_id(query(reg, EntanglementCounterpart, 1, 12, Val(false); filo=true)) == (slot = reg[2], tag = Tag(EntanglementCounterpart,1,12))
-@test query(reg, EntanglementCounterpart, 1, 12, Val(false); filo=false) == query(reg, EntanglementCounterpart, 1, ==(12), Val(false); filo=false)
-@test query(reg, EntanglementCounterpart, 1, 12, Val(false); filo=true) == query(reg, EntanglementCounterpart, 1, ==(12), Val(false); filo=true)
-@test strip_id(query(reg, EntanglementCounterpart, 1, ❓, Val(false); filo=false)) == (slot = reg[2], tag = Tag(EntanglementCounterpart,1,12))
-@test strip_id(query(reg, EntanglementCounterpart, 1, ❓, Val(false); filo=true)) == (slot = reg[4], tag = Tag(EntanglementCounterpart,1,314))
+@test strip_id(query(reg, EntanglementCounterpart, 1, 12; filo=false)) == (slot = reg[2], tag = Tag(EntanglementCounterpart,1,12))
+@test strip_id(query(reg, EntanglementCounterpart, 1, 12; filo=true)) == (slot = reg[2], tag = Tag(EntanglementCounterpart,1,12))
+@test query(reg, EntanglementCounterpart, 1, 12; filo=false) == query(reg, EntanglementCounterpart, 1, ==(12); filo=false)
+@test query(reg, EntanglementCounterpart, 1, 12; filo=true) == query(reg, EntanglementCounterpart, 1, ==(12); filo=true)
+@test strip_id(query(reg, EntanglementCounterpart, 1, ❓; filo=false)) == (slot = reg[2], tag = Tag(EntanglementCounterpart,1,12))
+@test strip_id(query(reg, EntanglementCounterpart, 1, ❓; filo=true)) == (slot = reg[4], tag = Tag(EntanglementCounterpart,1,314))
 
 default_res = queryall(reg, EntanglementCounterpart, 1, ❓)
 default_res_id = [r.id for r in default_res]

--- a/test/test_tags_and_queries.jl
+++ b/test/test_tags_and_queries.jl
@@ -3,6 +3,7 @@ using QuantumSavory: tag_types
 using QuantumSavory.ProtocolZoo: EntanglementCounterpart
 using Test
 
+function f()
 @test tag_types.SymbolIntInt(:symbol1, 4, 5) == Tag(:symbol1, 4, 5)
 
 function strip_id(query_result)
@@ -147,9 +148,55 @@ id3 = tag!(reg[3], :symB, 3, 4)
 id3 = tag!(reg[4], :symB, 4, 5)
 @test untag!(reg[1], id1).tag == Tag(:symA, 1, 2)
 @test untag!(reg, id2).tag == Tag(:symB, 2, 3)
-@test_throws "Attempted to delete a nonexistent" untag!(reg, 100)
+@test_throws "Attempted to delete a nonexistent" untag!(reg, -1)
 #= # tests for commented out code -- better to stick to only `querydelete!` for untagging with queries
 @test_throws "Attempted to delete a tag matching a query, but no matching tag exists" untag!(reg, :symD, ❓, ❓)
 @test_throws "Attempted to delete a tag matching a query, but there is no unique match" untag!(reg, :symB, ❓, ❓)
 @test untag!(reg, :symB, 3, ❓).tag == Tag(:symB, 3, 4)
+=#
+end
+
+f()
+#using BenchmarkTools
+#@benchmark f()
+
+#=
+## before any simplification
+
+BenchmarkTools.Trial: 10000 samples with 1 evaluation.
+ Range (min … max):  134.635 μs …   6.296 ms  ┊ GC (min … max): 0.00% … 95.01%
+ Time  (median):     142.902 μs               ┊ GC (median):    0.00%
+ Time  (mean ± σ):   160.930 μs ± 240.887 μs  ┊ GC (mean ± σ):  8.04% ±  5.30%
+
+    ▂▇██▅▂
+  ▃▅███████▇▆▅▅▅▅▅▅▅▄▄▄▃▃▃▃▃▃▃▃▃▃▃▂▂▃▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▁▂▂▂▂ ▃
+  135 μs           Histogram: frequency by time          205 μs <
+
+ Memory estimate: 214.33 KiB, allocs estimate: 2649.
+
+## after first round of simplification
+
+BenchmarkTools.Trial: 10000 samples with 1 evaluation.
+ Range (min … max):  171.124 μs …  10.533 ms  ┊ GC (min … max): 0.00% … 96.97%
+ Time  (median):     182.391 μs               ┊ GC (median):    0.00%
+ Time  (mean ± σ):   200.198 μs ± 291.337 μs  ┊ GC (mean ± σ):  6.32% ±  4.33%
+
+    ▁▆███▇▃▂
+  ▁▃██████████▇▇▆▅▄▄▄▃▃▃▂▂▂▂▂▂▂▂▂▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁ ▃
+  171 μs           Histogram: frequency by time          256 μs <
+
+ Memory estimate: 226.64 KiB, allocs estimate: 2848.
+
+## after second round of simplification
+
+BenchmarkTools.Trial: 10000 samples with 1 evaluation.
+ Range (min … max):  331.740 μs …   6.718 ms  ┊ GC (min … max): 0.00% … 91.94%
+ Time  (median):     344.995 μs               ┊ GC (median):    0.00%
+ Time  (mean ± σ):   368.845 μs ± 261.286 μs  ┊ GC (mean ± σ):  5.52% ±  7.07%
+
+     ▅██▆▃▂
+  ▂▃▇███████▆▆▅▄▃▃▃▃▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▁▂▂▂▂▁▁▁▁▁▂▂▁▁▁▁▁▁▂▂▂▁▂ ▃
+  332 μs           Histogram: frequency by time          458 μs <
+
+ Memory estimate: 436.03 KiB, allocs estimate: 8666.
 =#

--- a/test/test_tags_and_queries.jl
+++ b/test/test_tags_and_queries.jl
@@ -3,14 +3,16 @@ using QuantumSavory: tag_types
 using QuantumSavory.ProtocolZoo: EntanglementCounterpart
 using Test
 
-function f()
-@test tag_types.SymbolIntInt(:symbol1, 4, 5) == Tag(:symbol1, 4, 5)
-
 function strip_id(query_result)
     return (;slot=query_result.slot, tag=query_result.tag)
 end
 
 strip_id(::Nothing) = nothing
+
+function f()
+
+##
+@test tag_types.SymbolIntInt(:symbol1, 4, 5) == Tag(:symbol1, 4, 5)
 
 r = Register(10)
 tag!(r[1], :symbol1, 2, 3)
@@ -149,54 +151,8 @@ id3 = tag!(reg[4], :symB, 4, 5)
 @test untag!(reg[1], id1).tag == Tag(:symA, 1, 2)
 @test untag!(reg, id2).tag == Tag(:symB, 2, 3)
 @test_throws "Attempted to delete a nonexistent" untag!(reg, -1)
-#= # tests for commented out code -- better to stick to only `querydelete!` for untagging with queries
-@test_throws "Attempted to delete a tag matching a query, but no matching tag exists" untag!(reg, :symD, ❓, ❓)
-@test_throws "Attempted to delete a tag matching a query, but there is no unique match" untag!(reg, :symB, ❓, ❓)
-@test untag!(reg, :symB, 3, ❓).tag == Tag(:symB, 3, 4)
-=#
 end
 
 f()
 #using BenchmarkTools
 #@benchmark f()
-
-#=
-## before any simplification
-
-BenchmarkTools.Trial: 10000 samples with 1 evaluation.
- Range (min … max):  134.635 μs …   6.296 ms  ┊ GC (min … max): 0.00% … 95.01%
- Time  (median):     142.902 μs               ┊ GC (median):    0.00%
- Time  (mean ± σ):   160.930 μs ± 240.887 μs  ┊ GC (mean ± σ):  8.04% ±  5.30%
-
-    ▂▇██▅▂
-  ▃▅███████▇▆▅▅▅▅▅▅▅▄▄▄▃▃▃▃▃▃▃▃▃▃▃▂▂▃▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▁▂▂▂▂ ▃
-  135 μs           Histogram: frequency by time          205 μs <
-
- Memory estimate: 214.33 KiB, allocs estimate: 2649.
-
-## after first round of simplification
-
-BenchmarkTools.Trial: 10000 samples with 1 evaluation.
- Range (min … max):  171.124 μs …  10.533 ms  ┊ GC (min … max): 0.00% … 96.97%
- Time  (median):     182.391 μs               ┊ GC (median):    0.00%
- Time  (mean ± σ):   200.198 μs ± 291.337 μs  ┊ GC (mean ± σ):  6.32% ±  4.33%
-
-    ▁▆███▇▃▂
-  ▁▃██████████▇▇▆▅▄▄▄▃▃▃▂▂▂▂▂▂▂▂▂▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁ ▃
-  171 μs           Histogram: frequency by time          256 μs <
-
- Memory estimate: 226.64 KiB, allocs estimate: 2848.
-
-## after second round of simplification
-
-BenchmarkTools.Trial: 10000 samples with 1 evaluation.
- Range (min … max):  331.740 μs …   6.718 ms  ┊ GC (min … max): 0.00% … 91.94%
- Time  (median):     344.995 μs               ┊ GC (median):    0.00%
- Time  (mean ± σ):   368.845 μs ± 261.286 μs  ┊ GC (mean ± σ):  5.52% ±  7.07%
-
-     ▅██▆▃▂
-  ▂▃▇███████▆▆▅▄▃▃▃▃▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▁▂▂▂▂▁▁▁▁▁▂▂▁▁▁▁▁▁▂▂▂▁▂ ▃
-  332 μs           Histogram: frequency by time          458 μs <
-
- Memory estimate: 436.03 KiB, allocs estimate: 8666.
-=#


### PR DESCRIPTION
This code is drastically simpler than the original implementation, but also much slower:

Kept here as a reference and for potential future work that might be both simpler and faster.

```
## before any simplification

BenchmarkTools.Trial: 10000 samples with 1 evaluation.
 Range (min … max):  134.635 μs …   6.296 ms  ┊ GC (min … max): 0.00% … 95.01%
 Time  (median):     142.902 μs               ┊ GC (median):    0.00%
 Time  (mean ± σ):   160.930 μs ± 240.887 μs  ┊ GC (mean ± σ):  8.04% ±  5.30%

    ▂▇██▅▂
  ▃▅███████▇▆▅▅▅▅▅▅▅▄▄▄▃▃▃▃▃▃▃▃▃▃▃▂▂▃▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▁▂▂▂▂ ▃
  135 μs           Histogram: frequency by time          205 μs <

 Memory estimate: 214.33 KiB, allocs estimate: 2649.

## after first round of simplification

BenchmarkTools.Trial: 10000 samples with 1 evaluation.
 Range (min … max):  171.124 μs …  10.533 ms  ┊ GC (min … max): 0.00% … 96.97%
 Time  (median):     182.391 μs               ┊ GC (median):    0.00%
 Time  (mean ± σ):   200.198 μs ± 291.337 μs  ┊ GC (mean ± σ):  6.32% ±  4.33%

    ▁▆███▇▃▂
  ▁▃██████████▇▇▆▅▄▄▄▃▃▃▂▂▂▂▂▂▂▂▂▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁ ▃
  171 μs           Histogram: frequency by time          256 μs <

 Memory estimate: 226.64 KiB, allocs estimate: 2848.

## after second round of simplification

BenchmarkTools.Trial: 10000 samples with 1 evaluation.
 Range (min … max):  331.740 μs …   6.718 ms  ┊ GC (min … max): 0.00% … 91.94%
 Time  (median):     344.995 μs               ┊ GC (median):    0.00%
 Time  (mean ± σ):   368.845 μs ± 261.286 μs  ┊ GC (mean ± σ):  5.52% ±  7.07%

     ▅██▆▃▂
  ▂▃▇███████▆▆▅▄▃▃▃▃▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▁▂▂▂▂▁▁▁▁▁▂▂▁▁▁▁▁▁▂▂▂▁▂ ▃
  332 μs           Histogram: frequency by time          458 μs <

 Memory estimate: 436.03 KiB, allocs estimate: 8666.
```