### PR TITLE
Fix observable call due to something being now a keyword

### DIFF
--- a/ext/QuantumSavoryMakie/QuantumSavoryMakie.jl
+++ b/ext/QuantumSavoryMakie/QuantumSavoryMakie.jl
@@ -150,7 +150,7 @@ function Makie.plot!(rn::RegisterNetPlot{<:Tuple{RegisterNet}})
         ## the colors and locations for various observables
         if !isnothing(rn[:observables][])
         for (O, rsidx, links) in rn[:observables][]
-            val = real(observable(tuple((network[rs...] for rs in rsidx)...), O, NaN))
+            val = real(observable(tuple((network[rs...] for rs in rsidx)...), O; something=NaN))
             # TODO issue a warning if val has (percentage-wise) significant imaginary component (here, for plotting, when we implicitly are taking the real part)
             for (iʳᵉᵍ, iˢˡᵒᵗ) in rsidx
                 xˢ = registercoords[iʳᵉᵍ][1]


### PR DESCRIPTION
I think this should solve https://buildkite.com/quantumsavory/quantumsavory/builds/465#01914295-bba4-45a9-9ce5-c1e56d8da52c but didn't test it so let's see if the test now passes