### PR TITLE
Adjust to aviatesk/JET.jl#532

### DIFF
--- a/test/test_jet.jl
+++ b/test/test_jet.jl
@@ -2,24 +2,7 @@ using Test
 using QuantumSavory, JET
 using DiffEqBase, Graphs, JumpProcesses, Makie, ResumableFunctions, ConcurrentSim, QuantumOptics, QuantumOpticsBase, QuantumClifford, Symbolics, WignerSymbols
 
-using JET: ReportPass, BasicPass, InferenceErrorReport, UncaughtExceptionReport
-
-# Custom report pass that ignores `UncaughtExceptionReport`
-# Too coarse currently, but it serves to ignore the various
-# "may throw" messages for runtime errors we raise on purpose
-# (mostly on malformed user input)
-struct MayThrowIsOk <: ReportPass end
-
-# ignores `UncaughtExceptionReport` analyzed by `JETAnalyzer`
-(::MayThrowIsOk)(::Type{UncaughtExceptionReport}, @nospecialize(_...)) = return
-
-# forward to `BasicPass` for everything else
-function (::MayThrowIsOk)(report_type::Type{<:InferenceErrorReport}, @nospecialize(args...))
-    BasicPass()(report_type, args...)
-end
-
 rep = report_package("QuantumSavory";
-    report_pass=MayThrowIsOk(), # TODO have something more fine grained than a generic "do not care about thrown errors"
     ignored_modules=(
         AnyFrameModule(DiffEqBase),
         AnyFrameModule(Graphs.LinAlg),
@@ -33,10 +16,10 @@ rep = report_package("QuantumSavory";
         AnyFrameModule(ResumableFunctions),
         AnyFrameModule(ConcurrentSim),
         AnyFrameModule(WignerSymbols),
-        ))
+    ))
 
 @show length(JET.get_reports(rep))
 @show rep
 
-@test length(JET.get_reports(rep)) <= 146
+@test length(JET.get_reports(rep)) <= 85
 @test_broken length(JET.get_reports(rep)) == 0


### PR DESCRIPTION
Some progress towards https://github.com/QuantumSavory/QuantumSavory.jl/issues/130.

JET used to report many problems with `Base.@kwdef` (see https://github.com/aviatesk/JET.jl/issues/487). https://github.com/aviatesk/JET.jl/pull/532 got rid of these reports, but the effect was not visible in this repo due to the custom `ReportPass` subtype. But this is no longer needed as well, as https://github.com/aviatesk/JET.jl/issues/477 has been fixed in the meantime (also via https://github.com/aviatesk/JET.jl/pull/532).
This change on its own already gets rid of many JET warnings. Since it is so many at once, I wanted to put this into its own PR.

- [n/a] The code is properly formatted and commented.
- [n/a] Substantial new functionality is documented within the docs.
- [n/a] All new functionality is tested.
- [ ] All of the automated tests on github pass.
- [x] We recently started enforcing formatting checks. If formatting issues are reported in the new code you have written, please correct them.