### PR TITLE
Piecemaker

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,6 +6,7 @@ version = "0.6.0"
 [deps]
 Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"
 ConcurrentSim = "6ed1e86c-fcaf-46a9-97e0-2b26a2cdb499"
+DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
 Graphs = "86223c79-3864-5bf0-83f7-82e725a168b6"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "QuantumSavory"
 uuid = "2de2e421-972c-4cb5-a0c3-999c85908079"
 authors = ["Stefan Krastanov <stefan@krastanov.org>"]
-version = "0.6"
+version = "0.6.0"
 
 [deps]
 Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"
@@ -22,6 +22,7 @@ QuantumSymbolics = "efa7fd63-0460-4890-beb7-be1bbdfbaeae"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 ResumableFunctions = "c5292f4c-5179-55e1-98c5-05642aab7184"
+Revise = "295af30f-e4ad-537b-8983-00126c2a3abe"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 SumTypes = "8e1ec7a9-0e02-4297-b0fe-6433085c89f2"
 

--- a/examples/piecemakerswitch/3_simple_run.jl
+++ b/examples/piecemakerswitch/3_simple_run.jl
@@ -1,9 +1,0 @@
-include("setup.jl")
-
-# Prepare all of the simulation components
-n, sim = prepare_simulation()
-
-step_ts = range(0, 10, step=0.1)
-for t in step_ts
-    run(sim, t) 
-end

--- a/examples/piecemakerswitch/3_simple_run.jl
+++ b/examples/piecemakerswitch/3_simple_run.jl
@@ -1,0 +1,9 @@
+include("setup.jl")
+
+# Prepare all of the simulation components
+n, sim = prepare_simulation()
+
+step_ts = range(0, 10, step=0.1)
+for t in step_ts
+    run(sim, t) 
+end

--- a/examples/piecemakerswitch/README.md
+++ b/examples/piecemakerswitch/README.md
@@ -1,0 +1,11 @@
+# System Overview
+
+A central switch node connects to **n** clients. The switch possesses **m = n + 1** qubit slots, while each client has a single qubit slot.
+
+# Entanglement Initiation
+
+At each clock tick, the switch initiates entanglement attempts with each of the **n** clients, resulting in **n** entanglement processes per cycle. Successful entanglement links are then merged into a GHZ (Greenberger–Horne–Zeilinger) state using an additional "piecemaker" qubit located in the \((n + 1)\)th slot of the switch node. This fusion process is assumed to occur instantaneously.
+
+# Fusion Operation
+
+The fusion operation consists of applying a **CNOT** gate followed by a measurement. This procedure allows the merging of two GHZ states into a single GHZ state, modulo any required Pauli corrections. We iterate over all existing entangled states at the switch node: in each iteration, the piecemaker qubit (initialized in the state \(|+\rangle\)) is fused with one of the existing entangled states. Once all clients went through the fusion operation, the piecemaker qubit is measured out. This completes the fusing process and all nodes are sharing an n-GHZ state

--- a/examples/piecemakerswitch/README.md
+++ b/examples/piecemakerswitch/README.md
@@ -1,11 +1,16 @@
 # System Overview
-
 A central switch node connects to **n** clients. The switch possesses **m = n + 1** qubit slots, while each client has a single qubit slot.
 
 # Entanglement Initiation
-
-At each clock tick, the switch initiates entanglement attempts with each of the **n** clients, resulting in **n** entanglement processes per cycle. Successful entanglement links are then merged into a GHZ (Greenberger–Horne–Zeilinger) state using an additional "piecemaker" qubit located in the \((n + 1)\)th slot of the switch node. This fusion process is assumed to occur instantaneously.
+At each clock tick, the switch initiates entanglement attempts with each of the **n** clients, resulting in **n** entanglement processes per cycle. Successful entanglement links are then merged into a GHZ (Greenberger–Horne–Zeilinger) state using an additional "piecemaker" qubit located in the \((n + 1)\)th slot of the switch node. This fusion process is assumed to occur instantaneously. Once all clients went through the fusion operation, the piecemaker qubit is measured out. This completes the fusing process and all nodes are sharing an n-GHZ state.
 
 # Fusion Operation
+The fusion operation consists of applying a **CNOT** gate followed by a measurement in the computational basis. This procedure allows the merging of two GHZ states into a single GHZ state, modulo any required Pauli corrections. We iterate over all existing entangled states with the switch node: in each iteration, the piecemaker qubit (initialized in the state \(|+\rangle\)) is fused with one of the existing entangled states. 
 
-The fusion operation consists of applying a **CNOT** gate followed by a measurement. This procedure allows the merging of two GHZ states into a single GHZ state, modulo any required Pauli corrections. We iterate over all existing entangled states at the switch node: in each iteration, the piecemaker qubit (initialized in the state \(|+\rangle\)) is fused with one of the existing entangled states. Once all clients went through the fusion operation, the piecemaker qubit is measured out. This completes the fusing process and all nodes are sharing an n-GHZ state
+# Noise 
+The memories residing the nodes' `Register`s suffer from depolarizing noise. The latter is modelled via Kraus operators applied to the current state's density matrix.
+
+### Troubleshooting
+In the current implementation, sending and receiving classical measurement messages is achieved via a `DelayQueue` channel connected to `MessageBuffer`s at the nodes. The `MessageBuffer` acts as a buffer that holds incoming messages and manages processes waiting for messages.
+
+Important Note: By design, message passing should not involve simulated time delays by default. Messages are expected to be delivered instantaneously in simulation time unless explicitly specified otherwise. However, during simulation, the following debug output from the EntanglementTracker indicates that a delay is being introduced unexpectedly: `@debug "EntanglementTracker @$(prot.node): Starting message wait at $(now(prot.sim)) with MessageBuffer containing: $(mb.buffer)"` in the `EntanglementTracker`. This results in distribution times > # rounds of entanglement attempts, which should not be the case.

--- a/examples/piecemakerswitch/setup.jl
+++ b/examples/piecemakerswitch/setup.jl
@@ -4,38 +4,47 @@ using Graphs
 using ConcurrentSim
 using ResumableFunctions
 using Distributions
+using DataFrames
 
-@resumable function init_piecemaker(sim, net, m)
-    while true
-        @yield lock(net[1][m])
-        if !isassigned(net[1][m])
-            initialize!(net[1][m], X1)
-            tag!(net[1][m], Piecemaker, 1, m)
-            unlock(net[1][m])
-            @yield timeout(sim, 0.1)
-        else
-            unlock(net[1][m])
-            @yield timeout(sim, 0.1)
-        end
-    end
-end
+# @resumable function init_piecemaker(sim, net, m)
+#     while true
+#         @yield lock(net[1][m])
+#         if !isassigned(net[1][m])
+#             initialize!(net[1][m], X1)
+#             tag!(net[1][m], Piecemaker, 1, m)
+#             unlock(net[1][m])
+#             @yield timeout(sim, 1e-9)
+#         else
+#             unlock(net[1][m])
+#             @yield timeout(sim, 1e-9)
+#         end
+#     end
+# end
         
 
 function prepare_simulation()
-    n = 5   # number of clients
+    n = 10   # number of clients
     m = n+1 # memory slots in switch is equal to the number of clients + 1 slot for piecemaker qubit
-    r_depol = 0#1e-5 # depolarization rate
+    depolar_prob = 0.1
+    r_depol =  - log(1 - depolar_prob) # depolarization rate
 
     # The graph of network connectivity. Index 1 corresponds to the switch.
     graph = star_graph(n+1)
 
     switch_register = Register(m, Depolarization(1/r_depol)) # the first slot is reserved for the 'piecemaker' qubit used as fusion qubit 
-    client_registers = [Register(1, Depolarization(1/r_depol)) for _ in 1:n]
+    client_registers = [Register(1,  Depolarization(1/r_depol)) for _ in 1:n]
+    @info switch_register.reprs[1]
     net = RegisterNet(graph, [switch_register, client_registers...])
     sim = get_time_tracker(net)
 
     # Set up the initial |+> state of the piecemaker qubit
-    @process init_piecemaker(sim, net, m)
+    initialize!(net[1][m], X1)
+    tag!(net[1][m], Piecemaker, 1, m)
+
+    event_ghz_state = Event(sim)
+
+    # Set up the initial |+> state of the piecemaker qubit
+    # @process init_piecemaker(sim, net, m)
 
     # Set up the entanglement trackers at each client
     trackers = [EntanglementTracker(sim, net, k) for k in 2:n+1]
@@ -44,12 +53,14 @@ function prepare_simulation()
     end
 
     # Set up an entanglement consumer between each unordered pair of clients
-    consumer = GHZConsumer(net, net[1][m])
+    consumer = GHZConsumer(net, net[1][m], event_ghz_state)
     @process consumer()
 
     # Finally, set up the switch without assignments
-    switch_protocol = FusionSwitchDiscreteProt(net, 1, 2:n+1, fill(0.1, n))
+    switch_protocol = FusionSwitchDiscreteProt(net, 1, 2:n+1, fill(0.5, n))
     @process switch_protocol()
+
     
-    return n, sim
+    
+    return n, sim, consumer
 end

--- a/examples/piecemakerswitch/setup.jl
+++ b/examples/piecemakerswitch/setup.jl
@@ -22,14 +22,15 @@ end
         
 
 function prepare_simulation()
-    n = 4   # number of clients
+    n = 5   # number of clients
     m = n+1 # memory slots in switch is equal to the number of clients + 1 slot for piecemaker qubit
+    r_depol = 0#1e-5 # depolarization rate
 
     # The graph of network connectivity. Index 1 corresponds to the switch.
     graph = star_graph(n+1)
 
-    switch_register = Register(m) # the first slot is reserved for the 'piecemaker' qubit used as fusion qubit 
-    client_registers = [Register(1) for _ in 1:n]
+    switch_register = Register(m, Depolarization(1/r_depol)) # the first slot is reserved for the 'piecemaker' qubit used as fusion qubit 
+    client_registers = [Register(1, Depolarization(1/r_depol)) for _ in 1:n]
     net = RegisterNet(graph, [switch_register, client_registers...])
     sim = get_time_tracker(net)
 
@@ -47,7 +48,7 @@ function prepare_simulation()
     @process consumer()
 
     # Finally, set up the switch without assignments
-    switch_protocol = FusionSwitchDiscreteProt(net, 1, 2:n+1, fill(0.7, n))
+    switch_protocol = FusionSwitchDiscreteProt(net, 1, 2:n+1, fill(0.1, n))
     @process switch_protocol()
     
     return n, sim

--- a/examples/piecemakerswitch/setup.jl
+++ b/examples/piecemakerswitch/setup.jl
@@ -33,7 +33,6 @@ function prepare_simulation()
 
     switch_register = Register(m, Depolarization(1/r_depol)) # the first slot is reserved for the 'piecemaker' qubit used as fusion qubit 
     client_registers = [Register(1,  Depolarization(1/r_depol)) for _ in 1:n]
-    @info switch_register.reprs[1]
     net = RegisterNet(graph, [switch_register, client_registers...])
     sim = get_time_tracker(net)
 

--- a/examples/piecemakerswitch/setup.jl
+++ b/examples/piecemakerswitch/setup.jl
@@ -1,0 +1,54 @@
+using QuantumSavory
+using QuantumSavory.ProtocolZoo
+using Graphs
+using ConcurrentSim
+using ResumableFunctions
+using Distributions
+
+@resumable function init_piecemaker(sim, net, m)
+    while true
+        @yield lock(net[1][m])
+        if !isassigned(net[1][m])
+            initialize!(net[1][m], X1)
+            tag!(net[1][m], Piecemaker, 1, m)
+            unlock(net[1][m])
+            @yield timeout(sim, 0.1)
+        else
+            unlock(net[1][m])
+            @yield timeout(sim, 0.1)
+        end
+    end
+end
+        
+
+function prepare_simulation()
+    n = 4   # number of clients
+    m = n+1 # memory slots in switch is equal to the number of clients + 1 slot for piecemaker qubit
+
+    # The graph of network connectivity. Index 1 corresponds to the switch.
+    graph = star_graph(n+1)
+
+    switch_register = Register(m) # the first slot is reserved for the 'piecemaker' qubit used as fusion qubit 
+    client_registers = [Register(1) for _ in 1:n]
+    net = RegisterNet(graph, [switch_register, client_registers...])
+    sim = get_time_tracker(net)
+
+    # Set up the initial |+> state of the piecemaker qubit
+    @process init_piecemaker(sim, net, m)
+
+    # Set up the entanglement trackers at each client
+    trackers = [EntanglementTracker(sim, net, k) for k in 2:n+1]
+    for tracker in trackers
+        @process tracker()
+    end
+
+    # Set up an entanglement consumer between each unordered pair of clients
+    consumer = GHZConsumer(net, net[1][m])
+    @process consumer()
+
+    # Finally, set up the switch without assignments
+    switch_protocol = FusionSwitchDiscreteProt(net, 1, 2:n+1, fill(0.7, n))
+    @process switch_protocol()
+    
+    return n, sim
+end

--- a/examples/piecemakerswitch/simple_run.jl
+++ b/examples/piecemakerswitch/simple_run.jl
@@ -1,0 +1,9 @@
+include("setup.jl")
+
+# Prepare all of the simulation components
+n, sim, consumer = prepare_simulation()
+
+run(sim)
+
+df = DataFrame(consumer.log, [:DistributionTime, :Fidelity, :NaN])
+@info df

--- a/examples/piecemakerswitch/simple_run.jl
+++ b/examples/piecemakerswitch/simple_run.jl
@@ -1,9 +1,17 @@
 include("setup.jl")
 
+results = DataFrame(DistributionTime=Float64[], Fidelity=Float64[])
+nruns = 10
+
 # Prepare all of the simulation components
-n, sim, consumer = prepare_simulation()
+for i in 1:nruns
+    n, sim, consumer = prepare_simulation()
+    run(sim)
 
-run(sim)
+    tuple_result = consumer.log[1]  # Since it's just one tuple
 
-df = DataFrame(consumer.log, [:DistributionTime, :Fidelity, :NaN])
-@info df
+    df_run = DataFrame(consumer.log, [:DistributionTime, :Fidelity])
+    append!(results, df_run)
+end
+
+@info results

--- a/src/CircuitZoo/CircuitZoo.jl
+++ b/src/CircuitZoo/CircuitZoo.jl
@@ -3,7 +3,7 @@ module CircuitZoo
 using QuantumSavory
 using DocStringExtensions
 
-export EntanglementSwap, LocalEntanglementSwap,
+export EntanglementFusion, EntanglementSwap, LocalEntanglementSwap,
     Purify2to1, Purify2to1Node, Purify3to1, Purify3to1Node,
     PurifyStringent, PurifyStringentNode, PurifyExpedient, PurifyExpedientNode,
     SDDecode, SDEncode
@@ -46,6 +46,16 @@ end
 
 inputqubits(::LocalEntanglementSwap) = 2
 
+struct EntanglementFusion <: AbstractCircuit
+end
+
+function (::EntanglementFusion)(localq,  piecemaker)
+    apply!((piecemaker, localq), CNOT)
+    zmeas = project_traceout!(localq, σᶻ)
+    zmeas
+end
+
+inputqubits(::EntanglementFusion) = 2
 
 """
 $TYPEDEF

--- a/src/ProtocolZoo/ProtocolZoo.jl
+++ b/src/ProtocolZoo/ProtocolZoo.jl
@@ -627,8 +627,8 @@ end
 
         (q, id, tag) = fusable_qubit.slot, fusable_qubit.id, fusable_qubit.tag
         (q_pm, id_pm, tag_pm) = piecemaker.slot, piecemaker.id, piecemaker.tag
-        @yield lock(q) & lock(q_pm) # this should not really need a yield thanks to `findswapablequbits`, but it is better to be defensive
-        @yield timeout(prot.sim, prot.local_busy_time)
+        #@yield lock(q) & lock(q_pm) # this should not really need a yield thanks to `findswapablequbits`, but it is better to be defensive
+        #@yield timeout(prot.sim, prot.local_busy_time)
 
         untag!(q, id)
         # store a history of whom we were entangled to for both client slot and piecemaker

--- a/src/ProtocolZoo/ProtocolZoo.jl
+++ b/src/ProtocolZoo/ProtocolZoo.jl
@@ -536,10 +536,13 @@ end
             (slot, id, tag) = pm[1]
             untag!(prot.piecemaker, id)
 
-            ob1 = real(observable(client_slots, tensor(collect(fill(Z, nclients))...)))
-            ob2 = real(observable(client_slots, tensor(collect(fill(X, nclients))...)))
+            result = observable(client_slots, projector(1/sqrt(2)*(reduce(⊗, [fill(Z1,nclients)...]) + reduce(⊗,[fill(Z2,nclients)...]))))
+            @info result
+
+            # ob1 = real(observable(client_slots, tensor(collect(fill(Z, nclients))...)))
+            # ob2 = real(observable(client_slots, tensor(collect(fill(X, nclients))...)))
             # if nclients-GHZ state achieved both observables equal 1 
-            @info "GHZConsumer: expectation values $(ob1) $(ob2)" 
+            @info "GHZConsumer: expectation value $(result)" 
             
             # delete tags and free client slots
             for k in 2:nclients+1
@@ -550,7 +553,8 @@ end
             end
             
             traceout!([prot.net[k][1] for k in 2:nclients+1]...)
-            push!(prot.log, (now(prot.sim), ob1, ob2))
+            push!(prot.log, (now(prot.sim), result, 0.))
+            @info prot.log
 
             for k in 2:nclients+1
                 unlock(prot.net[k][1])

--- a/src/ProtocolZoo/switches.jl
+++ b/src/ProtocolZoo/switches.jl
@@ -187,7 +187,6 @@ FusionSwitchDiscreteProt(net, switchnode, clientnodes, success_probs; kwrags...)
 
         # perform fusions
         _switch_run_fusions(prot, matches)
-        #@yield timeout(prot.sim, prot.ticktock/2) # TODO this is a pretty arbitrary value # TODO timeouts should work on prot and on net
     end
 end
 

--- a/src/backends/quantumoptics/uptotime.jl
+++ b/src/backends/quantumoptics/uptotime.jl
@@ -72,3 +72,8 @@ function krausops(d::AmplitudeDamping, Δt, basis) # https://quantumcomputing.st
 end
 
 # TODO add an amplitude damping example of transduction
+
+function krausops(Depol::Depolarization, Δt)
+    p = 1-exp(-Δt/Depol.τ) # TODO check this
+    [√(1-3*p/4) * _id, √(p/4) * _x, √(p/4) * _y, √(p/4) * _z]
+end


### PR DESCRIPTION
This PR adds a new quantum network example: A central switch node connects to n clients. The switch possesses m = n + 1 qubit slots, while each client has a single qubit slot. At each clock tick, the switch initiates entanglement attempts with each of the n clients, resulting in n entanglement processes per cycle. Successful entanglement links are then merged into a GHZ (Greenberger–Horne–Zeilinger) state using an additional "piecemaker" qubit located in the (n + 1)th slot of the switch node. This fusion process is assumed to occur instantaneously. Once all clients went through the fusion operation, the piecemaker qubit is measured out completing one simulation run. The fidelity of the generated GHZ state as well as distribution times of each run are collected.

### Changes
* `uptotime.jl`: implemented `struct Depolarization` noise using `krausops` which can be applied to a `Register` 
* `switches.jl`: added `struct FusionSwitchDiscreteProt` as the main protocol including `function _switch_entangler_all_selected(prot)` and other functions. The latter runs the entangler protocol between all clients and their respective (preselected) slots at the switch node.
* `ProtocolZoo.jl`: added tags `FusionCounterpart` and `Piecemaker` indicating/to query a new qubit available to be fused into the GHZ state and the piecemaker qubit, respectively. Added `struct GHZConsumer` which measures out the piecemaker qubit in the end, tracking the distribution time, as well as the fidelity of the final state with the target GHZ state.
* `CircuitZoo.jl`: added `struct EntanglementFusion` circuit.
* new file `setup.jl`: prepares simulation processes.
* new file `simple_run.jl`: runs simulation and collects results from the `GHZConsumer.log`.

### Troubleshooting
In the current implementation, sending and receiving classical measurement messages is achieved via a `DelayQueue` channel connected to `MessageBuffer`s at the nodes. The `MessageBuffer` acts as a buffer that holds incoming messages and manages processes waiting for messages.

Important Note: By design, message passing should not involve simulated time delays by default. Messages are expected to be delivered instantaneously in simulation time unless explicitly specified otherwise. However, during simulation, the following debug output from the EntanglementTracker indicates that a delay is being introduced unexpectedly: `@debug "EntanglementTracker @$(prot.node): Starting message wait at $(now(prot.sim)) with MessageBuffer containing: $(mb.buffer)"` in the `EntanglementTracker`. This results in distribution times > # rounds of entanglement attempts, which should not be the case.

