### PR TITLE
Avoid method-override warnings in tests by using separate modules

### DIFF
--- a/examples/colorcentermodularcluster/1_time_to_connected.jl
+++ b/examples/colorcentermodularcluster/1_time_to_connected.jl
@@ -26,13 +26,13 @@ end
 
 # Run a quick check that the simulation works.
 # The first run will be slow as the code has to first compile.
-@time run_until_connected(root_conf)
+run_until_connected(root_conf)
 
 ##
 # Run a hundred simulations in multiple parallel threads
 # and store the results in a dataframe.
 
-@time r = tmap((_)->run_until_connected(root_conf), 1:100);
+r = tmap((_)->run_until_connected(root_conf), 1:100);
 df = rename(DataFrame(r), [:time,:fid])
 
 ##

--- a/examples/firstgenrepeater/6.1_compare_formalisms_noplot.jl
+++ b/examples/firstgenrepeater/6.1_compare_formalisms_noplot.jl
@@ -65,10 +65,10 @@ nologging = ConsoleLogger(stderr, Logging.Warn)
 # Run sims
 replicates = 100
 sampled_times = 0.:0.4:25.
-@time qo_res = with_logger(nologging) do
+qo_res = with_logger(nologging) do
     [monte_carlo_trajectory(; sampled_times) for _ in 1:replicates]
 end;
-@time qc_res = with_logger(nologging) do
+qc_res = with_logger(nologging) do
     [monte_carlo_trajectory(; sampled_times, representation=CliffordRepr) for _ in 1:replicates]
 end;
 

--- a/examples/firstgenrepeater/6_compare_formalisms.jl
+++ b/examples/firstgenrepeater/6_compare_formalisms.jl
@@ -67,10 +67,10 @@ nologging = ConsoleLogger(stderr, Logging.Warn)
 # Run sims
 replicates = 100
 sampled_times = 0.:0.2:25.
-@time qo_res = with_logger(nologging) do
+qo_res = with_logger(nologging) do
     [monte_carlo_trajectory(; sampled_times) for _ in 1:replicates]
 end;
-@time qc_res = with_logger(nologging) do
+qc_res = with_logger(nologging) do
     [monte_carlo_trajectory(; sampled_times, representation=CliffordRepr) for _ in 1:replicates]
 end;
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,6 +7,7 @@ function testfilter(tags)
     if get(ENV,"QUANTUMSAVORY_PLOT_TEST","")!="true"
         push!(exclude, :plotting_cairo)
         push!(exclude, :plotting_gl)
+        push!(exclude, :examples_plotting)
         push!(exclude, :doctests)
     end
     if get(ENV,"JET_TEST","")!="true"
@@ -15,5 +16,14 @@ function testfilter(tags)
     return all(!in(exclude), tags)
 end
 
+if get(ENV,"QUANTUMSAVORY_PLOT_TEST","")=="true"
+    include("setup_plotting.jl") # avoid the installation cost for GLMakie unless necessary
+end
+
 println("Starting tests with $(Threads.nthreads()) threads out of `Sys.CPU_THREADS = $(Sys.CPU_THREADS)`...")
 @run_package_tests filter=ti->testfilter(ti.tags) verbose=true
+
+if get(ENV,"QUANTUMSAVORY_PLOT_TEST","")=="true"
+    import GLMakie
+    GLMakie.closeall() # to avoid errors when running headless
+end

--- a/test/setup_plotting.jl
+++ b/test/setup_plotting.jl
@@ -1,2 +1,3 @@
+println("installing GLMakie for plotting tests")
 using Pkg
 Pkg.add("GLMakie")

--- a/test/test_examples.jl
+++ b/test/test_examples.jl
@@ -1,55 +1,52 @@
-@testitem "Examples - colorcentermodularcluster" tags=[:examples] begin
+@testitem "Examples - colorcentermodularcluster 1" tags=[:examples] begin
     include("../examples/colorcentermodularcluster/1_time_to_connected.jl")
-    if get(ENV,"QUANTUMSAVORY_PLOT_TEST","")=="true"
-        include("../examples/colorcentermodularcluster/2_real_time_visualization.jl")
-    end
 end
 
-@testitem "Examples - congestionchain" tags=[:examples] begin
-    if get(ENV,"QUANTUMSAVORY_PLOT_TEST","")=="true"
-        include("setup_plotting.jl")
-        include("../examples/congestionchain/1_visualization.jl")
-    end
+@testitem "Examples - colorcentermodularcluster 2" tags=[:examples_plotting] begin
+    include("../examples/colorcentermodularcluster/2_real_time_visualization.jl")
 end
 
-@testitem "Examples - firstgenrepeater" tags=[:examples] begin
-    if get(ENV,"QUANTUMSAVORY_PLOT_TEST","")=="true"
-        include("setup_plotting.jl")
-        include("../examples/firstgenrepeater/1_entangler_example.jl")
-        include("../examples/firstgenrepeater/2_swapper_example.jl")
-        include("../examples/firstgenrepeater/3_purifier_example.jl")
-        include("../examples/firstgenrepeater/4_visualization.jl")
-        include("../examples/firstgenrepeater/5_clifford_full_example.jl")
-        include("../examples/firstgenrepeater/6_compare_formalisms.jl")
-    end
+@testitem "Examples - congestionchain" tags=[:examples_plotting] begin
+    include("../examples/congestionchain/1_visualization.jl")
+end
+
+@testitem "Examples - firstgenrepeater 1" tags=[:examples_plotting] begin
+    include("../examples/firstgenrepeater/1_entangler_example.jl")
+end
+@testitem "Examples - firstgenrepeater 2" tags=[:examples_plotting] begin
+    include("../examples/firstgenrepeater/2_swapper_example.jl")
+end
+@testitem "Examples - firstgenrepeater 3" tags=[:examples_plotting] begin
+    include("../examples/firstgenrepeater/3_purifier_example.jl")
+end
+@testitem "Examples - firstgenrepeater 4" tags=[:examples_plotting] begin
+    include("../examples/firstgenrepeater/4_visualization.jl")
+end
+@testitem "Examples - firstgenrepeater 5" tags=[:examples_plotting] begin
+    include("../examples/firstgenrepeater/5_clifford_full_example.jl")
+end
+@testitem "Examples - firstgenrepeater 6" tags=[:examples_plotting] begin
+    include("../examples/firstgenrepeater/6_compare_formalisms.jl")
+end
+@testitem "Examples - firstgenrepeater 6.1" tags=[:examples] begin
     include("../examples/firstgenrepeater/6.1_compare_formalisms_noplot.jl")
 end
 
-@testitem "Examples - firstgenrepeater_v2" tags=[:examples] begin
-    if get(ENV,"QUANTUMSAVORY_PLOT_TEST","")=="true"
-        include("setup_plotting.jl")
-        include("../examples/firstgenrepeater_v2/1_entangler_example.jl")
-        include("../examples/firstgenrepeater_v2/2_swapper_example.jl")
-    end
+@testitem "Examples - firstgenrepeater_v2 1" tags=[:examples_plotting] begin
+    include("../examples/firstgenrepeater_v2/1_entangler_example.jl")
+end
+@testitem "Examples - firstgenrepeater_v2 2" tags=[:examples_plotting] begin
+    include("../examples/firstgenrepeater_v2/2_swapper_example.jl")
 end
 
-@testitem "Examples - simpleswitch" tags=[:examples] begin
-    if get(ENV,"QUANTUMSAVORY_PLOT_TEST","")=="true"
-        # TODO-MATCHING due to the dependence on BlossomV.jl this has trouble installing. See https://github.com/JuliaGraphs/GraphsMatching.jl/issues/14
-        #include("setup_plotting.jl")
-        #include("../examples/simpleswitch/1_interactive_visualization.jl")
-    end
+@testitem "Examples - simpleswitch" tags=[:examples_plotting] begin
+    # TODO-MATCHING due to the dependence on BlossomV.jl this has trouble installing. See https://github.com/JuliaGraphs/GraphsMatching.jl/issues/14
+    #include("../examples/simpleswitch/1_interactive_visualization.jl")
 end
 
-@safetestset "repeatergrid" begin
-    if get(ENV, "QUANTUMSAVORY_PLOT_TEST","")=="true"
-        include("setup_plotting.jl")
-        include("../examples/repeatergrid/1a_async_interactive_visualization.jl")
-        include("../examples/repeatergrid/2a_sync_interactive_visualization.jl")
-    end
+@safetestset "Examples - repeatergrid 1a" tags=[:examples_plotting] begin
+    include("../examples/repeatergrid/1a_async_interactive_visualization.jl")
 end
-
-if get(ENV,"QUANTUMSAVORY_PLOT_TEST","")=="true"
-    import GLMakie
-    GLMakie.closeall() # to avoid errors when running headless
+@safetestset "Examples - repeatergrid 2a" tags=[:examples_plotting] begin
+    include("../examples/repeatergrid/2a_sync_interactive_visualization.jl")
 end

--- a/test/test_plotting_cairo.jl
+++ b/test/test_plotting_cairo.jl
@@ -1,5 +1,4 @@
 @testitem "Plotting Cairo" tags=[:plotting_cairo] begin
-include("setup_plotting.jl")
 using CairoMakie
 CairoMakie.activate!()
 

--- a/test/test_plotting_gl.jl
+++ b/test/test_plotting_gl.jl
@@ -1,5 +1,4 @@
 @testitem "Plotting GL" tags=[:plotting_gl] begin
-    include("setup_plotting.jl")
     using GLMakie
     GLMakie.activate!()
 

--- a/test/test_quantumchannel.jl
+++ b/test/test_quantumchannel.jl
@@ -1,3 +1,4 @@
+end
 @testitem "Quantum Channel" tags=[:quantumchannel] begin
 using ResumableFunctions
 using ConcurrentSim
@@ -32,6 +33,14 @@ sref = regB.staterefs[1]
 @test sref.registers[1] == sref.registers[2]
 @test !isassigned(regA, 1)
 
+end
+
+@testitem "Quantum Channel - alternative constructor" tags=[:quantumchannel] begin
+using ResumableFunctions
+using ConcurrentSim
+
+bell = (Z1⊗Z1 + Z2⊗Z2)/sqrt(2.0)
+
 ## Test with the second constructor
 
 regA = Register(1)
@@ -51,6 +60,14 @@ run(sim)
 sref = regB.staterefs[1]
 @test sref.registers[1] == sref.registers[2]
 @test !isassigned(regA, 1)
+
+end
+
+@testitem "Quantum Channel with T1 decay" tags=[:quantumchannel] begin
+using ResumableFunctions
+using ConcurrentSim
+
+bell = (Z1⊗Z1 + Z2⊗Z2)/sqrt(2.0)
 
 ## Test with T1Decay
 
@@ -75,6 +92,14 @@ initialize!(reg[1:2], bell)
 uptotime!(reg[1], 10.0)
 
 @test observable(reg[1:2], projector(bell)) ≈ observable(regB[1:2], projector(bell))
+
+end
+
+@testitem "Quantum Channel with T2 dephasing" tags=[:quantumchannel] begin
+using ResumableFunctions
+using ConcurrentSim
+
+bell = (Z1⊗Z1 + Z2⊗Z2)/sqrt(2.0)
 
 ## Test with T2Dephasing
 


### PR DESCRIPTION
By splitting the example tests in separate modules (each `@testitem` creates its own module) now we have separate namespaces and no worries about overwriting of methods.

I also removed a few other sources of spurious messages.

Lastly, I reorganized how the setup and tear-down for OpenGL plotting tests happens, hopefully leading to fewer crashes in buildkite.