### PR TITLE
fixes to background noise processes, implementing more of them, documentation

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -28,7 +28,8 @@ function main()
     "Explanations" => [
         "explanations.md",
         "Register Interface" => "register_interface.md",
-        "Properties and Backgrounds" => "propbackgrounds.md",
+        "Properties" => "properties.md",
+        "Background Noise" => "backgrounds.md",
         "Symbolic Expressions" => "symbolics.md",
         "Tagging and Querying" => "tag_query.md",
         "Visualizations" => "visualizations.md",

--- a/docs/src/backgrounds.md
+++ b/docs/src/backgrounds.md
@@ -1,0 +1,15 @@
+# Background Noise Processes
+
+For each subsystem (slot in the register), you also specify what background processes and noise parameters describe it.
+For instance, it could be a [`T1Decay`](@ref) or [`T2Dephasing`](@ref) process, or a coherent error, or a non-Markovian bath.
+It is supported by all backends (but maybe with twirling, e.g. to support `T1Decay` in a Clifford simulation).
+
+Currently we implement:
+
+```@example subtypes
+using QuantumSavory # hide
+using InteractiveUtils # hide
+subtypes(QuantumSavory.AbstractBackground)
+```
+
+If you want to introspect these noise processes, you can use the [`paulinoise`](@ref), [`krausops`](@ref), and [`lindbladop`](@ref) functions.

--- a/docs/src/howto/firstgenrepeater/firstgenrepeater.md
+++ b/docs/src/howto/firstgenrepeater/firstgenrepeater.md
@@ -57,7 +57,7 @@ The `RegisterNet` would contain, on each node:
     To see how to visualize these data structures as the simulation is proceeding, consult the [Visualizations](@ref Visualizations) page.
 
 !!! note
-    To see how to define imperfections, noise processes, and background events, consult the [Sub-system Properties](@ref Properties-and-Backgrounds) page.
+    To see how to define imperfections, noise processes, and background events, consult the [Sub-system Background Noise](@ref "Background Noise Processes") page.
 
 ```@raw html
 <details><summary>Click to expand and see code used to set up the meta-graph and registers</summary>
@@ -536,7 +536,7 @@ We used the [`Register`](@ref) data structure to automatically track the quantum
 describing our mixed analog-digital quantum dynamics.
 
 Much of the analog dynamics was implicit through the use of [backgrounds,
-declaring the noise properties of various qubits](@ref Properties-and-Backgrounds).
+declaring the noise properties of various qubits](@ref "Background Noise Processes").
 
 The digital-ish dynamics was implemented through the use of
 - [`initialize!`](@ref) for setting initial states to various qubits

--- a/docs/src/propbackgrounds.md
+++ b/docs/src/propbackgrounds.md
@@ -1,7 +1,0 @@
-# [Properties and Backgrounds](@id Properties-and-Backgrounds)
-
-When creating a new registers, you can specify what type of physical system it will contain in each slot,
-e.g. a [`Qubit`](@ref) or a qudit or a harmonic oscillator or a propagating wave packet.
-
-For each subsystem (slot in the register), you also specify what background processes and noise parameters describe it.
-For instance, it could be a [`T1Decay`](@ref) or [`T2Dephasing`](@ref) process, or a coherent error, or a non-Markovian bath.

--- a/docs/src/properties.md
+++ b/docs/src/properties.md
@@ -1,0 +1,4 @@
+# Properties
+
+When creating a new registers, you can specify what type of physical system it will contain in each slot,
+e.g. a [`Qubit`](@ref) or a qudit or a harmonic oscillator or a propagating wave packet.

--- a/docs/src/visualizations.md
+++ b/docs/src/visualizations.md
@@ -51,7 +51,7 @@ initialize!(net[2,3], X₁) # hide
 initialize!((net[3,1],net[4,2]), X₁⊗Z₂) # hide
 apply!((net[2,3],net[3,1]), CNOT) # hide
 using Tyler
-ax = generate_map()
+subfig, ax, map = generate_map()
 fig, ax, plt, obs = registernetplot_axis(ax, net, registercoords=[Point2f(-118, 34), Point2f(-71, 42), Point2f(-111, 34), Point2f(-96, 32)])
 fig
 ```

--- a/ext/QuantumSavoryTylerMakie/QuantumSavoryTylerMakie.jl
+++ b/ext/QuantumSavoryTylerMakie/QuantumSavoryTylerMakie.jl
@@ -8,18 +8,18 @@ import QuantumSavory: generate_map
 
 """
 Generates a default map and returns an axis. The returned axis can be used as an input for `registernetplot_axis`.
-"""
-function generate_map(subfig::Makie.GridPosition; extent=nothing)
+""" # subfig::Union{GridPosition, GridSubposition} but maybe other as well, so leave it unspecified
+function generate_map(subfig; extent=nothing)
     if isnothing(extent)
         extent = Rect2f(-125, 24, 58, 25) # US Map
     end
     map = Tyler.Map(extent; figure=subfig, crs=Tyler.wgs84)
-    return map.axis
+    return subfig, map.axis, map
 end
 
 function generate_map(;extent=nothing)
     fig = Makie.Figure()
-    generate_map(fig[1, 1]; extent)
+    generate_map(fig; extent)
 end
 
 end

--- a/src/QuantumSavory.jl
+++ b/src/QuantumSavory.jl
@@ -70,7 +70,11 @@ export
     # noninstant.jl
     AbstractNoninstantOperation, NonInstantGate, ConstantHamiltonianEvolution,
     # plots.jl
-    registernetplot, registernetplot!, registernetplot_axis, resourceplot_axis, generate_map
+    registernetplot, registernetplot!, registernetplot_axis, resourceplot_axis, generate_map,
+    # backends/quantumoptics
+    krausops, lindbladop,
+    # backends/quantumclifford
+    paulinoise
 
 
 #TODO you can not assume you can always in-place modify a state. Have all these functions work on stateref, not stateref[]

--- a/src/backends/clifford/uptotime.jl
+++ b/src/backends/clifford/uptotime.jl
@@ -1,11 +1,43 @@
 function uptotime!(state::QuantumClifford.MixedDestabilizer, idx::Int, background, Δt)
-    prob, op = paulinoise(background, Δt)
-    if rand() > prob
-        QuantumClifford.apply!(state, op(idx))
+    cumprob = 1.0
+    r = rand()
+    for (prob, op) in paulinoise(background, Δt)
+        cumprob -= prob
+        if r > cumprob
+            QuantumClifford.apply!(state, op(idx))
+            break
+        end
     end
     state
 end
 
+"""
+For a given background noise type, provide the corresponding (potentially twirled) Pauli operators and the probabilities for the operators to act, in a QuantumClifford.jl representation.
+
+See also: [`krausops`](@ref), [`lindbladop`](@ref)
+"""
+function paulinoise end
+
+"""
+The Pauli operator and probability of its application for a T₂ process.
+
+`(1-exp(-Δt/T₂)) / 2` and `Z`
+"""
 function paulinoise(T2::T2Dephasing, Δt)
-    exp(-Δt/T2.t2), QuantumClifford.sZ
+    p = 1-exp(-Δt/T2.t2)
+    ((p/2, QuantumClifford.sZ),)
+end
+
+"""
+The Pauli operator and probability of its application for a Depolarization process.
+
+`((p/4, X), (p/4, Y), (p/4, Z))` for `p = 1-exp(-Δt/τ)`
+"""
+function paulinoise(D::Depolarization, Δt)
+    p = 1-exp(-Δt/D.τ)
+    ((p/4, QuantumClifford.sX), (p/4, QuantumClifford.sY), (p/4, QuantumClifford.sZ))
+end
+
+function paulinoise(P::PauliNoise)
+    error("we do not have pauli operators implemented for PauliNoise")
 end

--- a/src/backends/quantumoptics/noninstant.jl
+++ b/src/backends/quantumoptics/noninstant.jl
@@ -1,5 +1,3 @@
-export lindbladop
-
 function apply_noninstant!(state::Operator, state_indices::Vector{Int}, operation::ConstantHamiltonianEvolution, backgrounds)
     Δt = operation.duration
     base = basis(state)
@@ -15,26 +13,36 @@ function apply_noninstant!(state::Ket, state_indices::Vector{Int}, operation::Co
     apply_noninstant!(dm(state), state_indices, operation, backgrounds)
 end
 
+"""
+For a given background noise type, provide the corresponding Lindblad collapse operator, in a QuantumOptics.jl representation.
+
+See also: [`paulinoise`](@ref), [`krausops`](@ref)
+"""
+function lindbladop end
+
 function lindbladop(b::AbstractBackground, basis) # shortcircuit for backgrounds that work on a single basis
     lindbladop(b)
 end
 
+"`1/√T₁ |0⟩⟨1|`"
 function lindbladop(T1::T1Decay)
     1/√T1.t1 * _lh
 end
 
+"`1/√τ â`"
 function lindbladop(d::AmplitudeDamping, basis)
     1/√d.τ * destroy(basis)
 end
 
-function lindbladop(T2::T2Dephasing) # TODO pay attention to the √2 necessary to match to kraus operators
+"`1/√(2T₂) Z`"
+function lindbladop(T2::T2Dephasing)
     1 / √(2*T2.t2) * _z
 end
 
 function lindbladop(D::Depolarization)
-    # TODO
+    error("we do not have lindblad operators implemented for Depolarization")
 end
 
 function lindbladop(P::PauliNoise)
-    # TODO
+    error("we do not have lindblad operators implemented for PauliNoise")
 end

--- a/src/backends/quantumoptics/uptotime.jl
+++ b/src/backends/quantumoptics/uptotime.jl
@@ -1,5 +1,3 @@
-export krausops
-
 function uptotime!(state::StateVector, idx::Int, background, Δt)
     state = dm(state)
     uptotime!(state, idx, background, Δt)
@@ -51,24 +49,62 @@ const _cphase = _ll⊗_Id + _hh⊗_z
 const _phase = _ll + im*_hh
 const _iphase = _ll - im*_hh
 
+"""
+For a given background noise type, provide the corresponding Kraus operators, in a QuantumOptics.jl representation.
+
+See also: [`paulinoise`](@ref), [`lindbladop`](@ref)
+"""
+function krausops end
+
 function krausops(b::AbstractBackground, Δt, basis) # shortcircuit for backgrounds that work on a single basis
     return krausops(b, Δt)
 end
 
-# TODO move to QuantumSymbolics (and remove the above constants)
-function krausops(T1::T1Decay, Δt) # TODO checks comparing krausops and lindbladops
+"""
+The Kraus operators for a T₁ process
+
+- `A₁ = |0⟩⟨0| + √(1-γ) |1⟩⟨1|`
+- `A₂ = √γ |0⟩⟨1|`
+- `λ = 1 - exp(-Δt/T₁)`
+"""
+function krausops(T1::T1Decay, Δt)
     p = exp(-Δt/T1.t1) # TODO check this
     [√(1-p) * _lh, √p * _hh + _ll]
 end
 
+"""
+The Kraus operators for a T₂ process
+
+One option is the following (more popular in the literature):
+- `P₁ = |0⟩⟨0| + √(1-λ) |1⟩⟨1|`
+- `P₂ = √λ |1⟩⟨1|`
+- `λ = 1 - exp(-2Δt/T₂)`
+
+An equivalent option is (more convenient when converting to a Pauli error channel):
+- `P₁′ = √(1-p/2) I`
+- `P₂′ = √(p/2) Z`
+- `p = 1 - exp(-Δt/T₂)`
+
+These two options are equivalent under a unitary transformation. We implement the second one.
+"""
 function krausops(T2::T2Dephasing, Δt)
-    p = 1-exp(-Δt/T2.t2) # TODO check this
+    p = 1-exp(-Δt/T2.t2)
     [√(1-p/2) * _id, √(p/2) * _z]
-    #[√(1-p) * _id, √(p) * _hh, √(p) * _ll]
 end
 
 function krausops(d::AmplitudeDamping, Δt, basis) # https://quantumcomputing.stackexchange.com/questions/6828/amplitude-damping-of-a-harmonic-oscillator
-    nothing # TODO maybe encode this as a trait
+    nothing # TODO strictly speaking this is not necessary as we can always fall back to the lindbladians
 end
 
-# TODO add an amplitude damping example of transduction
+"""
+The Kraus operators for depolarization are
+`√(1-3p/4) I, √p/2 * X, √p/2 * Y, √p/2 Z`
+"""
+function krausops(D::Depolarization, Δt)
+    p = 1-exp(-Δt/D.τ)
+    [√(1-3p/4) * _id, √(p)/2 * _x, √(p)/2 * _y, √(p)/2 * _z]
+end
+
+function krausops(P::PauliNoise)
+    nothing # TODO strictly speaking this is not necessary as we can always fall back to the lindbladians
+end

--- a/src/backgrounds.jl
+++ b/src/backgrounds.jl
@@ -8,7 +8,11 @@ struct T2Dephasing <: AbstractBackground
     t2
 end
 
-"""A depolarization background."""
+"""A depolarization background.
+
+The `τ` parameter specifies the average time between depolarization events (assuming a Poisson point process).
+I.e. after time `t` the probability for an depolarization event is `1-exp(-t/τ)`.
+"""
 struct Depolarization <: AbstractBackground
     τ
 end
@@ -24,3 +28,8 @@ end
 struct AmplitudeDamping <: AbstractBackground
     τ
 end
+
+# TODO
+# T1T2Noise
+# T1TwirledDecay
+# T1T2TwirledNoise

--- a/test/test_noninstant_and_backgrounds_clifford.jl
+++ b/test/test_noninstant_and_backgrounds_clifford.jl
@@ -1,0 +1,49 @@
+@testitem "Noninstant and Backgrounds - Clifford" begin
+using QuantumSavory
+using Statistics: mean
+
+##
+# state vector vs clifford comparison of background noise processes
+
+function run_evolution(reg, init, gate, obs)
+    if isa(init, Tuple)
+        i1, i2 = init
+        initialize!(reg[1], i1)
+        initialize!(reg[2], i2)
+    else
+        initialize!((reg[1],reg[2]), init)
+    end
+    uptotime!(reg[2],0.1)
+    uptotime!(reg[2],0.2)
+    apply!((reg[1],reg[2]), gate)
+    uptotime!(reg[1],0.4)
+    uptotime!(reg[2],0.3)
+    uptotime!(reg[2],0.4)
+    obs = observable((reg[1],reg[2]), obs)
+    return obs
+end
+
+function vector_vs_clifford_test(background, init, gate, obs)
+    reg_qo() = Register([Qubit(),Qubit()],[background, background])
+    reg_qc() = Register([Qubit(),Qubit()],[CliffordRepr(),CliffordRepr()],[background, background])
+    obs_qo = run_evolution(reg_qo(), init, gate, obs)
+    samples = 1000
+    obs_qc = mean([run_evolution(reg_qc(), init, gate, obs) for _ in 1:samples])
+    #println("$(real(obs_qo)), $(real(obs_qc))")
+    return abs(obs_qo - obs_qc) < 4/sqrt(samples)
+end
+
+for l in (X1, X2, Z1, Z2, Y1, Y2)
+    for r in (X1, X2, Z1, Z2, Y1, Y2)
+        for obs in (X⊗X, Z⊗Z, X⊗Y)
+            for gate in (CNOT, CPHASE)
+                for init in ((l,r), (l⊗r)) # to check if subsystemcompose works properly
+                    @test vector_vs_clifford_test(T2Dephasing(1.0), init, gate, obs)
+                    @test vector_vs_clifford_test(Depolarization(1.0), init, gate, obs)
+                end
+            end
+        end
+    end
+end
+
+end

--- a/test/test_noninstant_and_backgrounds_qubit.jl
+++ b/test/test_noninstant_and_backgrounds_qubit.jl
@@ -1,5 +1,7 @@
-@testitem "Noninstant and Backgrounds Qubit" tags=[:noninstant_and_backgrounds_qubit] begin
+@testitem "Noninstant and Backgrounds - Qubit" begin
 using QuantumSavory: NonInstantGate
+using QuantumSavory
+using LinearAlgebra
 
 ##
 # Time of application and gate durations
@@ -16,7 +18,7 @@ apply!([reg[1],reg[2]], NonInstantGate(CNOT, 0.1))
 @test_throws ErrorException apply!(reg[1], H; time=0.55)
 
 ##
-# Kraus vs Lindblad
+# Kraus vs Lindblad comparison (should give the same results)
 function kraus_lindblad_test(background,initstate)
     reg = Register([Qubit(),Qubit()],[background, background])
     initialize!(reg[1], initstate)
@@ -34,11 +36,11 @@ function kraus_lindblad_test(background,initstate)
     uptotime!(regb[1],0.2)
     uptotime!(regb[2],0.1)
     uptotime!(regb[2],0.2)
-    @test reg.staterefs[1].state[]⊗reg.staterefs[2].state[] ≈ regb.staterefs[2].state[]
+    @test reg.staterefs[1].state[]⊗reg.staterefs[2].state[] ≈ regb.staterefs[2].state[] # compare composed vs not-composed evolution
 
-    apply!(reg[1],ConstantHamiltonianEvolution(IdentityOp(X1),0.1),time=0.3)
-    uptotime!(reg[2],0.4)
-    @test reg.staterefs[1].state[] ≈ reg.staterefs[2].state[]
+    apply!(reg[1],ConstantHamiltonianEvolution(IdentityOp(X1),0.1),time=0.3) # Lindblad evolution
+    uptotime!(reg[2],0.4)                                                    # Kraus evolution
+    @test reg.staterefs[1].state[] ≈ reg.staterefs[2].state[] # compare Kraus evolution vs Lindblad evolution
 
     apply!(regb[1],ConstantHamiltonianEvolution(IdentityOp(X1),0.1),time=0.3)
     uptotime!(regb[2],0.4)
@@ -53,4 +55,78 @@ kraus_lindblad_test(T2Dephasing(1.0),Z1)
 kraus_lindblad_test(T2Dephasing(1.0),Z2)
 kraus_lindblad_test(T2Dephasing(1.0),X1)
 kraus_lindblad_test(T2Dephasing(1.0),X2)
+
+##
+# Kraus composition check (the effect of two short Kraus operators should be the same as the effect of one long Kraus operator)
+
+function kraus_composition_test(background,initstate, obs)
+    reg = Register([Qubit(),Qubit()],[background, background])
+    initialize!(reg[1], initstate)
+    initialize!(reg[2], initstate)
+    uptotime!(reg[1],0.1)
+    uptotime!(reg[1],0.2)
+    uptotime!(reg[1],0.3)
+    uptotime!(reg[1],0.4)
+    uptotime!(reg[1],0.5)
+    uptotime!(reg[2],0.5)
+    o1 = observable(reg[1], obs)
+    o2 = observable(reg[2], obs)
+    #println("$o1 $o2")
+    return o1 ≈ o2
+end
+
+for state in (X1, X2, Z1, Z2, Y1, Y2)
+    for obs in (X, Z, Y)
+        @test kraus_composition_test(T1Decay(1.0),state,obs)
+        @test kraus_composition_test(T2Dephasing(1.0),state,obs)
+        @test kraus_composition_test(Depolarization(1.0),state,obs)
+    end
+end
+
+##
+# Kraus op normalization check
+
+function kraus_normed(kraus_ops)
+    # check we have properly normed kraus_ops
+    kraus_sum = sum((k'*k for k in kraus_ops))
+    return kraus_sum.data ≈ LinearAlgebra.I(size(kraus_ops[1],1))
+end
+
+for δ in [0.1,1.0,2.0,10.]
+    @test kraus_normed(krausops(T1Decay(1.0), δ))
+    @test kraus_normed(krausops(T2Dephasing(1.0), δ))
+    @test kraus_normed(krausops(Depolarization(1.0), δ))
+end
+
+##
+# Kraus equivalences and consistency checks for T2 noise
+
+function krausT2a(t) # manually reimplement one of the T2 representations
+    l = 1-exp(-2t)
+    [1 0; 0 sqrt(1-l)], [0 0; 0 sqrt(l)]
+end
+
+function krausT2b(t) # manually reimplement another of the T2 representations
+    p = 1-exp(-t)
+    i = sqrt(1-p/2)
+    z = sqrt(p/2)
+    [i 0; 0 i], [z 0; 0 -z]
+end
+
+function kraus_unitary_equivalence(kraus_ops_a, kraus_ops_b)
+    # get the linear operations that relates one set of kraus operators to another set of kraus operators
+    u = (hcat(vec.(kraus_ops_a)...)' / hcat(vec.(kraus_ops_b)...)')
+    # check that it is unitary
+    return abs(det(u)) ≈ 1
+end
+
+for δ in [0.1,1.0,2.0,10.]
+    t2 = [op.data for op in krausops(T2Dephasing(1.0), δ)]
+    t2a = krausT2a(δ)
+    t2b = krausT2b(δ)
+    @test kraus_unitary_equivalence(t2, t2a)
+    @test kraus_unitary_equivalence(t2, t2b)
+    @test kraus_unitary_equivalence(t2a, t2b)
+end
+
 end

--- a/test/test_noninstant_and_backgrounds_qumode.jl
+++ b/test/test_noninstant_and_backgrounds_qumode.jl
@@ -1,4 +1,4 @@
-@testitem "Noninstant and Backgrounds Qumode" tags=[:noninstant_and_backgrounds_qumode] begin
+@testitem "Noninstant and Backgrounds - Qumode" begin
 
 ##
 # Time of application and gate durations


### PR DESCRIPTION
There was a bug in the Clifford implementation of `T2Dephasing`, found by @KDGoodenough  and @Luisenden 

That is now fixed, and a significant amount of new tests are implemented:

- comparing Clifford simulation of noise vs state vector simulation
- verifying that Kraus operators for time t are equal to the composition of N Kraus operators for time t/N
- verifying known unitary equivalences between Kraus operators
- verifying normalization (sum of squares equal identity) for Kraus operators

And also implementing Depolarization both for vector and Clifford sims.

Closes #196 and unreported bugs.

@Luisenden , I know you have made significant new additions to the library in your private repo. We should coordinate so that we can make multiple very small PRs (which can be easily reviewed, unlike one large PR that will probably never get reviewed), to bring these improvements back in and allocate the corresponding bounties.