### PR TITLE
Tyler Map Fixes

### DIFF
--- a/docs/src/visualizations.md
+++ b/docs/src/visualizations.md
@@ -51,8 +51,9 @@ initialize!(net[2,3], X₁) # hide
 initialize!((net[3,1],net[4,2]), X₁⊗Z₂) # hide
 apply!((net[2,3],net[3,1]), CNOT) # hide
 using Tyler
+coords = [Point2f(-118, 34), Point2f(-71, 42), Point2f(-111, 34), Point2f(-96, 32)]
 subfig, ax, map = generate_map()
-fig, ax, plt, obs = registernetplot_axis(ax, net, registercoords=[Point2f(-118, 34), Point2f(-71, 42), Point2f(-111, 34), Point2f(-96, 32)])
+fig, ax, plt, obs = registernetplot_axis(ax, net, registercoords=coords, state_linecolor = :black)
 fig
 ```
 In general, if you have a custom background axis, you can use it as the axis parameter in `registerplot_axis`.

--- a/ext/QuantumSavoryMakie/QuantumSavoryMakie.jl
+++ b/ext/QuantumSavoryMakie/QuantumSavoryMakie.jl
@@ -313,6 +313,8 @@ function registernetplot_axis(ax::Makie.AbstractAxis, registersobservable; infoc
             Makie.autolimits!(ax)
         end
     end
+    # translating the plot so that it is in front of the background map
+    Makie.translate!(p, 0, 0, 10)
     ax.parent, ax, p, p[1]
 end
 

--- a/ext/QuantumSavoryTylerMakie/QuantumSavoryTylerMakie.jl
+++ b/ext/QuantumSavoryTylerMakie/QuantumSavoryTylerMakie.jl
@@ -4,6 +4,7 @@ using QuantumSavory
 using Makie
 using Tyler
 using Tyler.MapTiles
+using Tyler.TileProviders
 import QuantumSavory: generate_map
 
 """
@@ -13,7 +14,9 @@ function generate_map(subfig; extent=nothing)
     if isnothing(extent)
         extent = Rect2f(-125, 24, 58, 25) # US Map
     end
-    map = Tyler.Map(extent; figure=subfig, crs=Tyler.wgs84)
+    provider = TileProviders.CartoDB(:Positron)
+    map = Tyler.Map(extent; provider, figure=subfig, crs=Tyler.wgs84)
+    wait(map)
     return subfig, map.axis, map
 end
 


### PR DESCRIPTION
This PR includes three small updates related to the Tyler mapping functionality, all based on suggestions from @Krastanov:

1. Fixed an issue where the Tyler map wasn't loading correctly in the documentation (see issue #206) by using the wait function.

2. Resolved a bug where registers would disappear when zooming by ensuring they are in the foreground.

3. Changed the default map to Positron for a cleaner look.
