### PR TITLE
Speedup observable by avoiding outer products

### DIFF
--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -5,7 +5,7 @@ using QuantumSavory
 using QuantumSavory.ProtocolZoo
 using QuantumSavory: tag_types
 using QuantumOpticsBase: Ket, Operator
-using QuantumClifford: MixedDestabilizer
+using QuantumClifford: MixedDestabilizer, ghz
 
 const SUITE = BenchmarkGroup()
 
@@ -151,3 +151,12 @@ put!(mb, Tag(EntanglementCounterpart, 2, 23))
 put!(mb, Tag(EntanglementCounterpart, 1, 10))
 SUITE["tagquery"]["messagebuffer"]["query"] = @benchmarkable query(mb, EntanglementCounterpart, 6, ❓)
 SUITE["tagquery"]["messagebuffer"]["querydelete"] = @benchmarkable querydelete!(_mb, EntanglementCounterpart, 6, ❓) setup=(_mb = deepcopy(mb))  evals=1
+
+
+SUITE["quantumstates"] = BenchmarkGroup(["quantumstates"])
+SUITE["quantumstates"]["observable"] = BenchmarkGroup(["observable"])
+state = StabilizerState(ghz(5))
+proj = projector(state)
+express(state)
+express(proj)
+SUITE["quantumstates"]["observable"]["quantumoptics"] = @benchmarkable observable(reg[1:5], proj) setup=(reg=Register(10); initialize!(reg[1:5], state)) evals=1

--- a/src/backends/quantumoptics/quantumoptics.jl
+++ b/src/backends/quantumoptics/quantumoptics.jl
@@ -15,9 +15,32 @@ function observable(state::Union{<:Ket,<:Operator}, indices::Base.AbstractVecOrT
     operation = express(operation, QOR)
     # TODO if indices is ascending 1:n we can skip this embed -- such an improvement should be upstreamed to QuantumOpticsBase, so that embed is faster
     # TODO if nsubsystems(state) == 1 the embed should still work and be a no-op -- this should be upstreamed to QuantumInterface
-    op = nsubsystems(state) == 1 ? operation : embed(basis(state), indices, operation)
+    op = if nsubsystems(state) == 1
+        operation
+    else
+        if nsubsystems(state) == length(indices) && 1:length(indices) == indices
+            operation
+        else
+            embed(basis(state), indices, operation)
+        end
+    end
     expect(op, state)
 end
+
+# special case for projectors in order to avoid the overhead of an outer product
+function observable(state::Union{<:Ket,<:Operator}, indices::Base.AbstractVecOrTuple{Int}, proj::SProjector)
+    projket = express(proj.ket, QOR)
+    if nsubsystems(projket) == length(indices) == nsubsystems(state)
+        1:length(indices) != indices && (projket = permutesystems(projket, indices))
+        return _observable(state, projket)
+    else # TODO this branch still uses an outer product because we do not have a convenient contraction operation implemented when the dimensions differ
+        return observable(state, indices, express(proj, QOR))
+    end
+end
+
+_observable(a::Ket,b::Ket) = abs2(a'*b)
+_observable(a::Operator,b::Ket) = expect(a,b)
+_observable(a::Operator,b::Operator) = expect(a,b)
 
 function project_traceout!(state::Union{Ket,Operator},stateindex::Int,psis::Base.AbstractVecOrTuple{Ket})
     if nsubsystems(state) == 1 # TODO is there a way to do this in a single function, instead of _overlap vs _project_and_drop

--- a/src/backends/quantumoptics/should_upstream.jl
+++ b/src/backends/quantumoptics/should_upstream.jl
@@ -34,3 +34,6 @@ function _project_and_drop(state::Operator, project_on, basis_index)
     result = emproj*state*emproj'
     return _drop_singular_bases(result)
 end
+
+
+QuantumSymbolics.express(s::Union{<:Ket,<:Operator}, ::QuantumOpticsRepr) = s

--- a/test/test_aqua.jl
+++ b/test/test_aqua.jl
@@ -1,5 +1,7 @@
 @testitem "Aqua" tags=[:aqua] begin
 using Aqua
+using QuantumOpticsBase
+using QuantumSavory
 
 if get(ENV,"JET_TEST","")=="true"
 # JET generates new methods with ambiguities
@@ -9,10 +11,10 @@ else
 
 Aqua.test_all(QuantumSavory,
     ambiguities=(QuantumSavory; recursive=false),
-    piracies=(; treat_as_own=[QuantumSavory.Symbolic]),
+    piracies=(; treat_as_own=[QuantumSavory.Symbolic, QuantumOpticsBase.Ket, QuantumOpticsBase.Operator]),
     stale_deps=(; ignore=[:NetworkLayout]) # needed by package extension but not a condition of its loading
 )
 
-@test length(Aqua.Piracy.hunt(QuantumSavory)) == 6
+@test length(Aqua.Piracy.hunt(QuantumSavory)) == 7
 end
 end

--- a/test/test_circuitzoo_purification.jl
+++ b/test/test_circuitzoo_purification.jl
@@ -154,7 +154,7 @@ end
                     initialize!(r[3:4], noisy_pair)
                     initialize!(r[5:6], noisy_pair)
                     if Purify3to1(leaveout1, leaveout2)(r[1], r[2], r[3], r[5], r[4], r[6])==true
-                        @test_broken observable(r[1:2], projector(bell)) ≈ 0.0 # This is a probabilistic test. It has a small chance of triggering
+                        @test_broken observable(r[1:2], projector(bell)) ≈ 0.0 atol=1e-5 # This is a probabilistic test. It has a small chance of triggering
                     end
                 end
             end
@@ -253,7 +253,7 @@ end
                     ma = Purify3to1Node(leaveout1, leaveout2)(r[1], r[3], r[5])
                     mb = Purify3to1Node(leaveout1, leaveout2)(r[2], r[4], r[6])
                     if ma == mb
-                        @test_broken observable(r[1:2], projector(bell)) ≈ 0.0 # This is a probabilistic test. It has a small chance of triggering
+                        @test_broken observable(r[1:2], projector(bell)) ≈ 0.0 atol=1e-5 # This is a probabilistic test. It has a small chance of triggering
                     end
                 end
             end
@@ -300,7 +300,7 @@ end
             initialize!(r[(2*i-1):(2*i)], noisy_pair)
         end
         if PurifyStringent()(r[1], r[2], r[3:2:25]..., r[4:2:26]...) == true
-            @test_broken observable(r[1:2], projector(bell)) ≈ 0.0 # This is a probabilistic test. It has a small chance of triggering
+            @test_broken observable(r[1:2], projector(bell)) ≈ 0.0 atol=1e-5 # This is a probabilistic test. It has a small chance of triggering
         end
     end
 end
@@ -344,7 +344,7 @@ end
             initialize!(r[(2*i-1):(2*i)], noisy_pair)
         end
         if PurifyExpedient()(r[1], r[2], r[3:2:21]..., r[4:2:22]...) == true
-            @test_broken observable(r[1:2], projector(bell)) ≈ 0.0 # This is a probabilistic test. It has a small chance of triggering
+            @test_broken observable(r[1:2], projector(bell)) ≈ 0.0 atol=1e-5 # This is a probabilistic test. It has a small chance of triggering
         end
     end
 end

--- a/test/test_circuitzoo_purification.jl
+++ b/test/test_circuitzoo_purification.jl
@@ -35,7 +35,7 @@ end
                 if error==leaveout
                     # undetected error
                     @test Purify2to1(leaveout)(r[1:4]...)==true
-                    @test observable(r[1:2], projector(bell))≈0.0
+                    @test observable(r[1:2], projector(bell)) ≈ 0.0 atol=1e-5
                 else
                     # detected error
                     @test Purify2to1(leaveout)(r[1:4]...)==false
@@ -66,7 +66,7 @@ end
                     ma = Purify2to1Node(leaveout)(r[1], r[3])
                     mb = Purify2to1Node(leaveout)(r[2], r[4])
                     @test ma == mb
-                    @test observable(r[1:2], projector(bell))≈0.0
+                    @test observable(r[1:2], projector(bell)) ≈ 0.0 atol=1e-5
                 else
                     # detected error
                     ma = Purify2to1Node(leaveout)(r[1], r[3])
@@ -108,7 +108,7 @@ end
 
                         if error == leaveout1
                             @test Purify3to1(leaveout1, leaveout2)(r[1], r[2], r[3], r[5], r[4], r[6])==true
-                            @test observable(r[1:2], projector(bell))≈0.0
+                            @test observable(r[1:2], projector(bell)) ≈ 0.0 atol=1e-5
                         else
                             @test Purify3to1(leaveout1, leaveout2)(r[1], r[2], r[3], r[5], r[4], r[6])==false
                         end
@@ -201,7 +201,7 @@ end
                             ma = Purify3to1Node(leaveout1, leaveout2)(r[1], r[3], r[5])
                             mb = Purify3to1Node(leaveout1, leaveout2)(r[2], r[4], r[6])
                             @test ma == mb
-                            @test observable(r[1:2], projector(bell))≈0.0
+                            @test observable(r[1:2], projector(bell)) ≈ 0.0 atol=1e-5
                         else
                             ma = Purify3to1Node(leaveout1, leaveout2)(r[1], r[3], r[5])
                             mb = Purify3to1Node(leaveout1, leaveout2)(r[2], r[4], r[6])

--- a/test/test_observable.jl
+++ b/test/test_observable.jl
@@ -12,7 +12,7 @@
         @test observable(a[1:2], SProjector(bell)) ≈ 1.0
         @test observable(a[1:2], σˣ⊗σˣ) ≈ 1.0
         apply!(a[1], σʸ)
-        @test observable(a[1:2], SProjector(bell)) ≈ 0.0
+        @test observable(a[1:2], SProjector(bell)) ≈ 0.0 atol=1e-5
         @test observable(a[1:2], σˣ⊗σˣ) ≈ -1.0
     end
 end


### PR DESCRIPTION
Fixes #216 (at least partially -- it is a speadup of more than 10x for 5-qubit states)

```
BenchmarkTools.Trial: 10000 samples with 1 evaluation per sample.
 Range (min … max):   5.831 μs …   4.401 ms  ┊ GC (min … max):  0.00% … 99.13%
 Time  (median):      8.336 μs               ┊ GC (median):     0.00%
 Time  (mean ± σ):   13.733 μs ± 147.468 μs  ┊ GC (mean ± σ):  36.98% ±  3.43%

      ▁▃▄▄▄▄▇▄▆▆▇▆▆█▅▅▄▄▂▁▁
  ▁▂▅███████████████████████▇▆▆▄▅▄▃▃▃▃▃▃▃▂▂▂▂▂▂▂▂▂▂▂▂▁▂▂▁▁▁▁▁▁ ▄
  5.83 μs         Histogram: frequency by time           15 μs <

 Memory estimate: 28.28 KiB, allocs estimate: 160.
```

```
BenchmarkTools.Trial: 10000 samples with 1 evaluation per sample.
 Range (min … max):  400.000 ns …  11.031 μs  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     481.000 ns               ┊ GC (median):    0.00%
 Time  (mean ± σ):   522.458 ns ± 197.006 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

    ▃█▇ ▁
  ▂▄███▃█▇▅▆▆▂▅▅▅▅▅▅▂▄▄▄▄▄▂▄▃▃▃▃▂▃▃▃▃▃▁▃▃▃▃▃▁▃▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂ ▃
  400 ns           Histogram: frequency by time          912 ns <

 Memory estimate: 2.23 KiB, allocs estimate: 17.
```
