### PR TITLE
register slot locks in visualizations

### DIFF
--- a/ext/QuantumSavoryMakie/QuantumSavoryMakie.jl
+++ b/ext/QuantumSavoryMakie/QuantumSavoryMakie.jl
@@ -33,7 +33,7 @@ import QuantumSavory: registernetplot, registernetplot!, registernetplot_axis, r
         state_marker = :diamond,
         state_markercolor = :black,
         state_linecolor = :gray90,
-        lock_marker = '⚿',  # TODO plot the state of the locks
+        lock_marker = '⚿',
         # The registercoords and observables arguments are not considered "theme" configuration options
     )
 end
@@ -45,6 +45,7 @@ function Makie.plot!(rn::RegisterNetPlot{<:Tuple{RegisterNet}})
     register_rectangles = Observable(Rect2f[])     # Makie rectangles that will be plotted for each register
     register_slots_coords = Observable(Point2f[])  # Makie marker locations that will be plotted for each register slot
     state_coords = Observable(Point2f[])           # Makie marker locations for each slot that contains a state subsystem
+    lock_coords = Observable(Point2f[])            # Makie marker locations for each lock
     state_links = Observable(Point2f[])            # The lines connecting the state subsystem markers corresponding to the same composite system
     observables_coords = Observable(Point2f[])     # Makie marker locations that will be plotted for each subsystem on which an observable is evaluated
     observables_links = Observable(Point2f[])      # The links between observed subsystems
@@ -111,7 +112,7 @@ function Makie.plot!(rn::RegisterNetPlot{<:Tuple{RegisterNet}})
         registercoords = rn[:registercoords][]
         all_nodes = [ # TODO it is rather wasteful to replot everything... do it smarter
             register_rectangles, register_slots_coords,
-            state_coords, state_links,
+            state_coords, state_links, lock_coords,
             register_slots_coords_backref, state_coords_backref,
             observables_coords, observables_links, observables_vals, observables_linkvals
         ]
@@ -131,6 +132,9 @@ function Makie.plot!(rn::RegisterNetPlot{<:Tuple{RegisterNet}})
                 yˢˡᵒᵗ = registercoords[iʳᵉᵍ][2]+(iˢˡᵒᵗ-1)*rn[:scale][]
                 push!(register_slots_coords[], Point2f(xˢˡᵒᵗ,yˢˡᵒᵗ))
                 push!(register_slots_coords_backref[], (reg,iʳᵉᵍ,iˢˡᵒᵗ))
+                if reg.locks[iˢˡᵒᵗ].level >= 1
+                    push!(lock_coords[], Point2f(xˢˡᵒᵗ, yˢˡᵒᵗ))
+                end
             end
         end
 
@@ -215,6 +219,11 @@ function Makie.plot!(rn::RegisterNetPlot{<:Tuple{RegisterNet}})
         inspector_label = (self, i, p) -> get_state_vis_string(state_coords_backref[],i))
     state_linesegmentsplot = linesegments!(rn, state_links, color=rn[:state_linecolor])
     state_linesegmentsplot.inspectable[] = false
+    lock_scatterplot = scatter!(
+        rn, lock_coords,
+        marker=rn[:lock_marker], markersize=rn[:slotsize][]*rn[:scale][],
+        markerspace=:data)
+    lock_scatterplot.inspectable[] = false
 
     # TODO all of these should be wrapped into their own types in order to simplify DataInspector and process_interaction
     rn[:register_polyplot] = register_polyplot
@@ -223,6 +232,7 @@ function Makie.plot!(rn::RegisterNetPlot{<:Tuple{RegisterNet}})
     rn[:observables_linesegmentsplot] = observables_linesegments
     rn[:state_scatterplot] = state_scatterplot
     rn[:state_linesegmentsplot] = state_linesegmentsplot
+    rn[:lock_scatterplot] = lock_scatterplot
     rn
 end
 


### PR DESCRIPTION
Added locks drawn over register slots to show that they are locked.
All functionality, including updating the plot with notify works.

- [X] The code is properly formatted and commented.
- [ ] Substantial new functionality is documented within the docs.
- [X] All new functionality is tested.
- [ ] All of the automated tests on github pass.
- [X] Formatting

![registernetplot_example](https://github.com/user-attachments/assets/7f63b47f-e65d-48a9-8775-63b8533c3462)

Notes:
- The marker is probably not very visible. The color may be changed, or it can be drawn to the side (but drawing to the side causes line segments to be drawn over them) <details> <summary>Lock to the side (one second change, not committed) </summary>
![registernetplot_example](https://github.com/user-attachments/assets/32015c95-26fe-4d1a-91b3-fad7d0aa2256)
</details>

