### PR TITLE
Rename wait(::MessageBuffer) and onchange_tag(::Register) to onchange for consistency

### DIFF
--- a/examples/purificationMBQC/MBQC.jl
+++ b/examples/purificationMBQC/MBQC.jl
@@ -47,14 +47,14 @@ Tag(tag::PurifiedEntalgementCounterpart) = Tag(PurifiedEntalgementCounterpart, t
         local_tag = query(nodereg, MBQCMeasurement, node, ❓) # waits on the measurement result
 
         if isnothing(local_tag)
-            @yield onchange_tag(net[node])
+            @yield onchange(net[node])
             continue
         end
 
         msg = query(mb, MBQCMeasurement, ❓, ❓)
         if isnothing(msg)
             @debug "Starting message wait at $(now(sim)) with MessageBuffer containing: $(mb.buffer)"
-            @yield wait(mb)
+            @yield onchange(mb)
             @debug "Done waiting for message at $(node)"
             continue
         end
@@ -79,7 +79,7 @@ end
         query_setup = query(net[node], MBQCSetUp, node)
         if !isnothing(query_setup) # no need to set up if it already is
             if isnothing(period)
-                @yield onchange_tag(net[node])
+                @yield onchange(net[node])
             else
                 @yield timeout(sim, period)
             end
@@ -116,7 +116,7 @@ end
         query2 = query(net[node], MBQCSetUp, node)
         if length(query1) < 2 || isnothing(query2)
             if isnothing(period)
-                @yield onchange_tag(net[node])
+                @yield onchange(net[node])
             else
                 @yield timeout(sim, period)
             end

--- a/src/ProtocolZoo/ProtocolZoo.jl
+++ b/src/ProtocolZoo/ProtocolZoo.jl
@@ -1,7 +1,7 @@
 module ProtocolZoo
 
 using QuantumSavory
-import QuantumSavory: get_time_tracker, Tag, isolderthan, onchange_tag
+import QuantumSavory: get_time_tracker, Tag, isolderthan, onchange_tag, onchange
 using QuantumSavory: Wildcard
 using QuantumSavory.CircuitZoo: EntanglementSwap, LocalEntanglementSwap
 
@@ -232,7 +232,7 @@ end
         if isnothing(a_) || isnothing(b_)
             if isnothing(prot.retry_lock_time)
                 @debug "EntanglerProt between $(prot.nodeA) and $(prot.nodeB)|round $(round): Failed to find free slots. \nGot:\n1. \t $a_ \n2.\t $b_ \n waiting for changes to tags..."
-                @yield onchange_tag(prot.net[prot.nodeA]) | onchange_tag(prot.net[prot.nodeB])
+                @yield onchange(prot.net[prot.nodeA]) | onchange(prot.net[prot.nodeB])
             else
                 @debug "EntanglerProt between $(prot.nodeA) and $(prot.nodeB)|round $(round): Failed to find free slots. \nGot:\n1. \t $a_ \n2.\t $b_ \n waiting a fixed amount of time..."
                 @yield timeout(prot.sim, prot.retry_lock_time::Float64)
@@ -393,7 +393,7 @@ end
             end
         end
         @debug "EntanglementTracker @$(prot.node): Starting message wait at $(now(prot.sim)) with MessageBuffer containing: $(mb.buffer)"
-        @yield wait(mb)
+        @yield onchange(mb)
         @debug "EntanglementTracker @$(prot.node): Message wait ends at $(now(prot.sim))"
     end
 end
@@ -435,7 +435,7 @@ end
         if isnothing(query1)
             if isnothing(prot.period)
                 @debug "EntanglementConsumer between $(prot.nodeA) and $(prot.nodeB): query on first node found no entanglement. Waiting on tag updates in $(prot.nodeA)."
-                @yield onchange_tag(prot.net[prot.nodeA])
+                @yield onchange(prot.net[prot.nodeA])
             else
                 @debug "EntanglementConsumer between $(prot.nodeA) and $(prot.nodeB): query on first node found no entanglement. Waiting a fixed amount of time."
                 @yield timeout(prot.sim, prot.period::Float64)
@@ -446,7 +446,7 @@ end
             if isnothing(query2) # in case EntanglementUpdate hasn't reached the second node yet, but the first node has the EntanglementCounterpart
                 if isnothing(prot.period)
                     @debug "EntanglementConsumer between $(prot.nodeA) and $(prot.nodeB): query on second node found no entanglement (yet...). Waiting on tag updates in $(prot.nodeB)."
-                    @yield onchange_tag(prot.net[prot.nodeB])
+                    @yield onchange(prot.net[prot.nodeB])
                 else
                     @debug "EntanglementConsumer between $(prot.nodeA) and $(prot.nodeB): query on second node found no entanglement (yet...). Waiting a fixed amount of time."
                     @yield timeout(prot.sim, prot.period::Float64)

--- a/src/ProtocolZoo/cutoff.jl
+++ b/src/ProtocolZoo/cutoff.jl
@@ -70,7 +70,7 @@ end
             unlock(slot)
         end
         if isnothing(prot.period)
-            @yield onchange_tag(reg)
+            @yield onchange(reg)
         else
             @yield timeout(prot.sim, prot.period::Float64)
         end

--- a/src/ProtocolZoo/qtcp.jl
+++ b/src/ProtocolZoo/qtcp.jl
@@ -365,7 +365,7 @@ end
         end
 
         # wait until we have received a message
-        @yield wait(mb)
+        @yield onchange(mb)
     end
 end
 
@@ -413,7 +413,7 @@ end
         end
 
         # Wait until we have received a message
-        @yield wait(mb)
+        @yield onchange(mb)
     end
 end
 

--- a/src/ProtocolZoo/swapping.jl
+++ b/src/ProtocolZoo/swapping.jl
@@ -70,7 +70,7 @@ end
         if isnothing(qubit_pair_)
             if isnothing(prot.retry_lock_time)
                 @debug "SwapperProt: no swappable qubits found. Waiting for tag change..."
-                @yield onchange_tag(prot.net[prot.node])
+                @yield onchange(prot.net[prot.node])
             else
                 @debug "SwapperProt: no swappable qubits found. Waiting a fixed amount of time..."
                 @yield timeout(prot.sim, prot.retry_lock_time::Float64)

--- a/src/QuantumSavory.jl
+++ b/src/QuantumSavory.jl
@@ -62,7 +62,7 @@ export
     CliffordRepr, QuantumOpticsRepr, QuantumMCRepr,
     UseAsState, UseAsObservable, UseAsOperation,
     AbstractBackground,
-    onchange_tag,
+    onchange_tag, onchange,
     # networks.jl
     RegisterNet, channel, qchannel, messagebuffer,
     # initialize.jl

--- a/src/messagebuffer.jl
+++ b/src/messagebuffer.jl
@@ -96,3 +96,24 @@ end
 function Base.wait(mb::MessageBuffer)
     @process wait_process(mb.sim, mb)
 end
+
+"""
+Wait for changes to occur on a MessageBuffer or Register.
+
+For MessageBuffer, this waits for new messages to arrive.
+For Register, this waits for tag changes on the register.
+"""
+function onchange(mb::MessageBuffer)
+    @process wait_process(mb.sim, mb)
+end
+
+"""
+Wait for changes to occur on a MessageBuffer or Register with a specific tag type.
+
+This variant is reserved for future functionality to differentiate between 
+different types of changes (e.g., "changed tag" vs "changed register assignment").
+"""
+function onchange(mb::MessageBuffer, ::Type{T}) where {T}
+    # For now, this behaves the same as the basic version
+    onchange(mb)
+end

--- a/src/queries.jl
+++ b/src/queries.jl
@@ -294,7 +294,7 @@ julia> env = get_time_tracker(net);
 julia> @resumable function receive_tags(env)
            while true
                mb = messagebuffer(net, 2)
-               @yield wait(mb)
+               @yield onchange(mb)
                msg = querydelete!(mb, :second_tag, ❓, ❓)
                print("t=\$(now(env)): query returns ")
                if isnothing(msg)

--- a/src/states_registers.jl
+++ b/src/states_registers.jl
@@ -84,3 +84,13 @@ function onchange_tag(r::RegOrRegRef)
     register = get_register(r)
     return lock(register.tag_waiter[])
 end
+
+function onchange(r::RegOrRegRef)
+    register = get_register(r)
+    return lock(register.tag_waiter[])
+end
+
+function onchange(r::RegOrRegRef, ::Type{T}) where {T}
+    # For now, this behaves the same as the basic version
+    onchange(r)
+end

--- a/test/test_messagebuffer.jl
+++ b/test/test_messagebuffer.jl
@@ -8,7 +8,7 @@ env = get_time_tracker(net);
 @resumable function receive_tags(env)
     while true
         mb = messagebuffer(net, 2)
-        @yield wait(mb)
+        @yield onchange(mb)
         msg = querydelete!(mb, :second_tag, ❓, ❓)
         if isnothing(msg)
             # println("nothing")

--- a/test/test_semaphore.jl
+++ b/test/test_semaphore.jl
@@ -169,9 +169,9 @@ end
 
     @resumable function watcher(sim)
         push!(LOG, (now(sim), "watcher: start"))
-        @yield onchange_tag(reg[1])
+        @yield onchange(reg[1])
         push!(LOG, (now(sim), "watcher: got first tag"))
-        @yield onchange_tag(reg[1])
+        @yield onchange(reg[1])
         push!(LOG, (now(sim), "watcher: got second tag"))
     end
 
@@ -216,11 +216,11 @@ end
 
     @resumable function receiver(sim)
         push!(LOG, (now(sim), "receiver: start"))
-        @yield wait(mb)
+        @yield onchange(mb)
         push!(LOG, (now(sim), "receiver: got message"))
-        @yield wait(mb)
+        @yield onchange(mb)
         push!(LOG, (now(sim), "receiver: got second message"))
-        @yield wait(mb)
+        @yield onchange(mb)
         push!(LOG, (now(sim), "receiver: got third message"))
     end
 


### PR DESCRIPTION
## Summary
- Introduces unified `onchange` function for both MessageBuffer and Register types  
- Addresses issue #268 by providing consistent API for waiting on changes
- Updates all existing usage sites to use the new unified interface
- Maintains backward compatibility by keeping existing functions

## Changes Made
- Added `onchange(::MessageBuffer)` that delegates to existing `wait` functionality
- Added `onchange(::RegOrRegRef)` that delegates to existing `onchange_tag` functionality  
- Added `onchange(::Union{MessageBuffer,RegOrRegRef}, ::Type{Tag})` for future extensibility
- Updated all protocol files and examples to use `onchange` instead of `wait`/`onchange_tag`
- Exported the new `onchange` function in the main module

## Test Plan
- [x] All existing tests pass
- [x] Updated test files to use new `onchange` function
- [x] Verified backward compatibility (old functions still work)
- [x] Verified consistent behavior across MessageBuffer and Register types

Closes #268

🤖 Generated with [Claude Code](https://claude.ai/code)