### PR TITLE
Add dataset-compatible network builder

### DIFF
--- a/.agents/context/network/transport.md
+++ b/.agents/context/network/transport.md
@@ -3,7 +3,7 @@
 - **Context need:** Reference
 - **Open when:** Checking network construction, directional delays, classical forwarding, or quantum handoff behavior.
 - **Do not open when:** Developing protocol race logic, changing backend evolution, or browsing zoo catalogs.
-- **Review when:** `RegisterNet`, classical channels, message buffers, quantum channels, or delay configuration changes.
+- **Review when:** `RegisterNet`, `network_builder`, classical channels, message buffers, quantum channels, or delay configuration changes.
 
 ## Current transport boundaries
 
@@ -16,6 +16,14 @@ same simulation, or every register simulation must be unused at time zero (zero 
 empty event heap, and no active process). In the latter case, construction rehomes each
 register's slot locks and tag notifier to the first simulation. A nonzero or scheduled
 independent register is rejected.
+
+`network_builder` is the uniform construction path for an undirected `SimpleGraph`.
+It requires one finite, nonnegative delay for each graph edge, uses that delay for
+both channel types and directions, and creates the same nonempty `Register` at each
+vertex. Node and link protocol specifications must be cataloged by
+`ProtocolZoo.protocol_catalog_metadata`; the builder validates their public fields,
+constructs every protocol, and then schedules them. It returns the simulation without
+advancing it.
 
 Classical messages have two modes. Direct delivery sends to an adjacent destination
 buffer. Forwarded delivery follows the graph toward a non-adjacent node and incurs the
@@ -61,9 +69,9 @@ state handoff.
 
 ## Anchors
 
-- **Source:** [`src/networks.jl`](../../../src/networks.jl), [`src/messagebuffer.jl`](../../../src/messagebuffer.jl), and [`src/quantumchannel.jl`](../../../src/quantumchannel.jl) — network, classical, and quantum transport.
-- **Docs:** [`docs/src/classical_messaging.md`](../../../docs/src/classical_messaging.md) and [`docs/src/architecture.md`](../../../docs/src/architecture.md) — human messaging and architecture model.
-- **Test:** [`test/general/registernet_interface_tests.jl`](../../../test/general/registernet_interface_tests.jl), [`test/general/messagebuffer_tests.jl`](../../../test/general/messagebuffer_tests.jl), and [`test/general/quantumchannel_tests.jl`](../../../test/general/quantumchannel_tests.jl) — exercised construction and delivery behavior.
+- **Source:** [`src/networks.jl`](../../../src/networks.jl), [`src/network_builder.jl`](../../../src/network_builder.jl), [`src/messagebuffer.jl`](../../../src/messagebuffer.jl), and [`src/quantumchannel.jl`](../../../src/quantumchannel.jl) — network construction and transport.
+- **Docs:** [`docs/src/tutorial/dataset_network.md`](../../../docs/src/tutorial/dataset_network.md), [`docs/src/classical_messaging.md`](../../../docs/src/classical_messaging.md), and [`docs/src/architecture.md`](../../../docs/src/architecture.md) — dataset construction, messaging, and architecture.
+- **Test:** [`test/general/network_builder_tests.jl`](../../../test/general/network_builder_tests.jl), [`test/general/registernet_interface_tests.jl`](../../../test/general/registernet_interface_tests.jl), [`test/general/messagebuffer_tests.jl`](../../../test/general/messagebuffer_tests.jl), and [`test/general/quantumchannel_tests.jl`](../../../test/general/quantumchannel_tests.jl) — exercised construction and delivery behavior.
 
 ## Known gaps
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Add `dist_to_delay` and `network_builder` for constructing uniform register
+  networks from edge-keyed distance datasets and cataloged protocols.
 - `generate_map` now accepts a custom Tyler tile provider.
 - QTCP `LinkController` can now consume pairs from an independent `EntanglerProt` based on reciprocal `(remote_node, remote_slot, pair_id)` tags being present.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,7 @@
 
 ## Unreleased
 
-- Add `dist_to_delay` and `network_builder` for constructing uniform register
-  networks from edge-keyed distance datasets and cataloged protocols.
+- Add `dist_to_delay` and `network_builder` for easily constructing large register networks based on a template.
 - `generate_map` now accepts a custom Tyler tile provider.
 - QTCP `LinkController` can now consume pairs from an independent `EntanglerProt` based on reciprocal `(remote_node, remote_slot, pair_id)` tags being present.
 

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,6 +1,7 @@
 [deps]
 AnythingLLMDocs = "333fe5f5-19c9-4863-8caf-c9193e7dba62"
 CairoMakie = "13f3f980-e62b-5c42-98c6-ff1f3baf88f0"
+CommunicationNetworkDatasets = "85c54e6a-00c4-4051-8730-b30cc4c3bfa0"
 ConcurrentSim = "6ed1e86c-fcaf-46a9-97e0-2b26a2cdb499"
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
@@ -32,4 +33,5 @@ Tyler = "e170d443-b9d6-418a-9ee8-061e966341ef"
 QuantumSavory = {path = ".."}
 
 [compat]
+CommunicationNetworkDatasets = "0.1"
 PrettyPrint = "0.2.0"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -80,6 +80,7 @@ function main()
     ],
     "Tutorials" => [
         "tutorial.md",
+        "Build a Network from a Dataset" => "tutorial/dataset_network.md",
         "Measure and Remove Quantum Systems" => "tutorial/project_traceout.md",
         "Custom Swapper Protocol" => "tutorial/myswapperprot.md",
         "State Explorer" => "tutorial/state_explorer.md",

--- a/docs/src/tutorial.md
+++ b/docs/src/tutorial.md
@@ -7,6 +7,7 @@ come back here for focused follow-up topics.
 
 ## Current Tutorials
 
+- [Build a Network from a Dataset](tutorial/dataset_network.md)
 - [Measure and Remove Quantum Systems](tutorial/project_traceout.md)
 - [Custom Swapper Protocol](tutorial/myswapperprot.md)
 - [State Explorer](tutorial/state_explorer.md)

--- a/docs/src/tutorial/dataset_network.md
+++ b/docs/src/tutorial/dataset_network.md
@@ -1,0 +1,97 @@
+# [Build a Network from a Dataset](@id dataset-network)
+
+This tutorial loads a published network topology, converts its link distances
+to propagation delays, and schedules node and link protocols.
+
+## Load the topology
+
+```@example dataset_network
+using CairoMakie
+using CommunicationNetworkDatasets
+using QuantumSavory
+using QuantumSavory.ProtocolZoo: EntanglerProt, EntanglementTracker
+using Tyler
+
+CairoMakie.activate!(; visible=false) # hide
+
+topology = load_network("topology_bench", "arpanet")
+delays = dist_to_delay(topology.distances);
+```
+
+The dataset reports distances in metres. [`dist_to_delay`](@ref) uses a default
+propagation speed of ``2.0 \times 10^8`` metres per second and returns a new
+edge-keyed dictionary.
+
+## Build and schedule the network
+
+```@example dataset_network
+node_protocols = (EntanglementTracker => (;),)
+link_protocols = (EntanglerProt => (;),)
+
+(; sim, network) = network_builder(
+    topology.graph,
+    delays,
+    (2,);
+    node_protocols,
+    link_protocols,
+);
+```
+
+The empty named tuples select the protocol defaults. [`network_builder`](@ref)
+creates a two-slot register at every vertex. It applies `EntanglementTracker`
+to every node and `EntanglerProt` to every undirected edge. It also uses each
+edge delay for both directions of the classical and quantum channels.
+
+The protocols are scheduled, but the builder does not advance `sim`.
+
+## Plot the register locations
+
+The node table gives longitude and latitude in the same vertex order as the
+graph. Pass those coordinates to the register plot on a Tyler map.
+
+```@example dataset_network
+coordinates = Point2f.(
+    topology.nodes.longitude_deg,
+    topology.nodes.latitude_deg,
+)
+
+tile_url = "https://tiles.quantumsavory.org/styles/ci/{z}/{x}/{y}.png" # hide
+ci_key = get(ENV, "TILE_CI_KEY", "") # hide
+isempty(ci_key) || occursin(r"\A[0-9a-f]{64}\z", ci_key) || # hide
+    error("TILE_CI_KEY must contain 64 lowercase hexadecimal characters") # hide
+tile_url *= isempty(ci_key) ? "" : "?ci_key=$(ci_key)" # hide
+provider = Tyler.TileProviders.Provider( # hide
+    tile_url; # hide
+    max_zoom=13, # hide
+    attribution="Protomaps © OpenStreetMap contributors; hosted by QuantumSavory", # hide
+) # hide
+if false # hide
+fig, axis, map = generate_map()
+end # hide
+fig, axis, map = generate_map(; provider) # hide
+registernetplot_axis(axis, network; registercoords=coordinates);
+wait(map) # hide
+close(map) # hide
+fig
+```
+
+The simulation is still at time zero, so the figure contains only the empty
+register glyphs. It does not draw physical graph edges or generated
+quantum-state links.
+
+!!! note "Dataset attribution"
+    This tutorial uses the ARPANET topology from Virgillito et al.,
+    *Topology Bench: Systematic Graph Based Benchmarking for Optical Networks*,
+    [Zenodo record 13921775 (2024)](https://zenodo.org/records/13921775), under
+    the [Creative Commons Attribution 4.0 International
+    license](https://creativecommons.org/licenses/by/4.0/). Attribute the
+    Topology Bench authors and the per-topology sources named by that
+    collection. CommunicationNetworkDatasets.jl publishes a modified form with
+    normalized schemas and identifiers, distances converted from kilometres to
+    metres, and documented self-loops and duplicate undirected edges removed.
+    Basemap tiles: Protomaps © OpenStreetMap contributors; hosted by
+    QuantumSavory.
+
+Call `run(sim, stop_time)` separately when you are ready to run the protocols.
+Use more register slots if protocols on several incident links must retain
+entanglement at the same time.

--- a/src/QuantumSavory.jl
+++ b/src/QuantumSavory.jl
@@ -68,7 +68,7 @@ export
     AbstractBackground,
     onchange_tag, onchange,
     # networks.jl
-    RegisterNet, channel, qchannel, messagebuffer,
+    RegisterNet, channel, qchannel, messagebuffer, dist_to_delay, network_builder,
     # logging.jl
     LOG_GROUPS, simulation_log_context,
     # initialize.jl
@@ -175,6 +175,8 @@ include("CircuitZoo/CircuitZoo.jl")
 include("StatesZoo/StatesZoo.jl")
 
 include("ProtocolZoo/ProtocolZoo.jl")
+
+include("network_builder.jl")
 
 include("should_upstream.jl")
 include("precompile.jl")

--- a/src/network_builder.jl
+++ b/src/network_builder.jl
@@ -7,7 +7,7 @@ dictionary method returns a new `Dict` with the same edge keys and converted
 values.
 
 Distances must be finite and nonnegative. The propagation speed must be finite
-and positive.
+and positive. The computed delay must also be finite.
 
 ```jldoctest
 julia> dist_to_delay(200_000_000)
@@ -28,7 +28,12 @@ function dist_to_delay(distance_m::Real, speed_m_per_s::Real=2.0e8)
         speed_m_per_s,
         "speed_m_per_s must be finite and positive",
     ))
-    return distance_m / speed_m_per_s
+    delay = distance_m / speed_m_per_s
+    isfinite(delay) || throw(DomainError(
+        (distance_m, speed_m_per_s),
+        "distance_m / speed_m_per_s must be finite",
+    ))
+    return delay
 end
 
 function dist_to_delay(distances::AbstractDict, speed_m_per_s::Real=2.0e8)

--- a/src/network_builder.jl
+++ b/src/network_builder.jl
@@ -1,0 +1,287 @@
+"""
+    dist_to_delay(distance_m::Real, speed_m_per_s::Real=2.0e8)
+    dist_to_delay(distances::AbstractDict, speed_m_per_s::Real=2.0e8)
+
+Convert a distance in metres to a one-way propagation delay in seconds. The
+dictionary method returns a new `Dict` with the same edge keys and converted
+values.
+
+Distances must be finite and nonnegative. The propagation speed must be finite
+and positive.
+
+```jldoctest
+julia> dist_to_delay(200_000_000)
+1.0
+
+julia> using Graphs
+
+julia> dist_to_delay(Dict(Edge(1, 2) => 100_000_000))[Edge(1, 2)]
+0.5
+```
+"""
+function dist_to_delay(distance_m::Real, speed_m_per_s::Real=2.0e8)
+    isfinite(distance_m) && distance_m >= 0 || throw(DomainError(
+        distance_m,
+        "distance_m must be finite and nonnegative",
+    ))
+    isfinite(speed_m_per_s) && speed_m_per_s > 0 || throw(DomainError(
+        speed_m_per_s,
+        "speed_m_per_s must be finite and positive",
+    ))
+    return distance_m / speed_m_per_s
+end
+
+function dist_to_delay(distances::AbstractDict, speed_m_per_s::Real=2.0e8)
+    isfinite(speed_m_per_s) && speed_m_per_s > 0 || throw(DomainError(
+        speed_m_per_s,
+        "speed_m_per_s must be finite and positive",
+    ))
+    return Dict(edge => dist_to_delay(distance_m, speed_m_per_s) for
+                (edge, distance_m) in distances)
+end
+
+function _network_builder_error(message)
+    throw(ArgumentError("network_builder: $(message)"))
+end
+
+function _validate_protocol_specification(specification, expected_attachment)
+    specification isa Pair || _network_builder_error(
+        "each protocol specification must be `ProtocolType => NamedTuple`",
+    )
+    protocol_type, configured = specification
+    protocol_type isa Type &&
+        protocol_type <: ProtocolZoo.AbstractProtocol &&
+        isconcretetype(protocol_type) || _network_builder_error(
+            "$(repr(protocol_type)) must be a concrete subtype of ProtocolZoo.AbstractProtocol",
+        )
+    configured isa NamedTuple || _network_builder_error(
+        "the configuration for $(protocol_type) must be a NamedTuple",
+    )
+    applicable(ProtocolZoo.protocol_catalog_metadata, protocol_type) ||
+        _network_builder_error(
+            "$(protocol_type) is not available through ProtocolZoo.protocol_catalog_metadata",
+        )
+
+    metadata = ProtocolZoo.protocol_catalog_metadata(protocol_type)
+    expected_keys = (:attachment, :attachment_fields, :required_fields)
+    metadata isa NamedTuple && keys(metadata) == expected_keys ||
+        _network_builder_error(
+            "catalog metadata for $(protocol_type) must be a NamedTuple with fields $(expected_keys)",
+        )
+
+    attachment = metadata.attachment
+    attachment in (:network, :node, :edge) || _network_builder_error(
+        "catalog metadata for $(protocol_type) has invalid attachment $(repr(attachment))",
+    )
+    attachment == expected_attachment || _network_builder_error(
+        "$(protocol_type) is attached to $(repr(attachment)), not $(repr(expected_attachment))",
+    )
+
+    attachment_fields = metadata.attachment_fields
+    expected_roles = attachment === :network ? () :
+                     attachment === :node ? (:node,) :
+                     (:node_a, :node_b)
+    attachment_fields isa NamedTuple && keys(attachment_fields) == expected_roles ||
+        _network_builder_error(
+            "catalog metadata for $(protocol_type) must map attachment roles $(expected_roles)",
+        )
+    mapped_fields = Tuple(values(attachment_fields))
+    all(field -> field isa Symbol, mapped_fields) || _network_builder_error(
+        "catalog attachment fields for $(protocol_type) must be Symbols",
+    )
+    allunique(mapped_fields) || _network_builder_error(
+        "catalog attachment fields for $(protocol_type) must be unique",
+    )
+
+    constructor_fields = fieldnames(protocol_type)
+    for field in (:sim, :net)
+        field in constructor_fields || _network_builder_error(
+            "cataloged protocol $(protocol_type) must define the injected field $(repr(field))",
+        )
+    end
+    for field in mapped_fields
+        field in constructor_fields || _network_builder_error(
+            "catalog attachment field $(repr(field)) is not a field of $(protocol_type)",
+        )
+        field in (:sim, :net) && _network_builder_error(
+            "catalog attachment fields cannot use framework-injected field $(repr(field))",
+        )
+        startswith(String(field), "_") && _network_builder_error(
+            "catalog attachment fields cannot use private field $(repr(field))",
+        )
+    end
+
+    required_fields = metadata.required_fields
+    required_fields isa Tuple && all(field -> field isa Symbol, required_fields) ||
+        _network_builder_error(
+            "catalog required_fields for $(protocol_type) must be a tuple of Symbols",
+        )
+    allunique(required_fields) || _network_builder_error(
+        "catalog required_fields for $(protocol_type) must be unique",
+    )
+
+    configurable_fields = filter(constructor_fields) do field
+        field ∉ (:sim, :net) &&
+            field ∉ mapped_fields &&
+            !startswith(String(field), "_")
+    end
+    all(field -> field in configurable_fields, required_fields) ||
+        _network_builder_error(
+            "catalog required_fields for $(protocol_type) must name configurable fields",
+        )
+
+    for field in keys(configured)
+        if field in (:sim, :net) || field in mapped_fields
+            _network_builder_error(
+                "field $(repr(field)) of $(protocol_type) is supplied by network_builder",
+            )
+        elseif startswith(String(field), "_")
+            _network_builder_error(
+                "private field $(repr(field)) of $(protocol_type) is not configurable",
+            )
+        elseif field ∉ configurable_fields
+            _network_builder_error(
+                "unknown configurable field $(repr(field)) for $(protocol_type)",
+            )
+        end
+    end
+    missing_fields = filter(field -> field ∉ keys(configured), required_fields)
+    isempty(missing_fields) || _network_builder_error(
+        "configuration for $(protocol_type) is missing required fields $(Tuple(missing_fields))",
+    )
+
+    return (; protocol_type, configured, attachment_fields)
+end
+
+function _validate_protocol_specifications(specifications, expected_attachment)
+    specifications = specifications isa Pair ? (specifications,) : specifications
+    applicable(iterate, specifications) ||
+        _network_builder_error("protocol specifications must be iterable")
+    return [
+        _validate_protocol_specification(specification, expected_attachment)
+        for specification in specifications
+    ]
+end
+
+function _attachment_keywords(attachment_fields, values)
+    fields = Tuple(attachment_fields)
+    return NamedTuple{fields}(values)
+end
+
+"""
+    network_builder(
+        graph::SimpleGraph,
+        delays::AbstractDict,
+        register_args::Tuple;
+        node_protocols=(),
+        link_protocols=(),
+    ) -> (; sim, network)
+
+Build a register network for `graph` without running its simulation. One
+nonempty `Register(register_args...)` is created per vertex. `delays` must have
+exactly one finite, nonnegative value for every undirected graph edge; that
+value is used for both directions of both the classical and quantum channels.
+
+Each protocol specification is a `ProtocolType => NamedTuple`. Node protocol
+types must have `:node` attachment metadata and are instantiated on every
+vertex. Link protocol types must have `:edge` attachment metadata and are
+instantiated on every undirected edge. `sim`, `net`, and the catalog-mapped
+attachment fields are injected by the builder. All protocols are instantiated
+before any protocol is scheduled.
+
+```jldoctest
+julia> using Graphs
+
+julia> graph = path_graph(3);
+
+julia> delays = Dict(edge => 0.01 for edge in edges(graph));
+
+julia> result = network_builder(graph, delays, (2,));
+
+julia> (nv(result.network), length(result.network[1]))
+(3, 2)
+```
+"""
+function network_builder(
+    graph::SimpleGraph,
+    delays::AbstractDict,
+    register_args::Tuple;
+    node_protocols=(),
+    link_protocols=(),
+)
+    nv(graph) > 0 || _network_builder_error("graph must contain at least one vertex")
+
+    graph_edges = Set(edges(graph))
+    delay_edges = Set(keys(delays))
+    graph_edges == delay_edges || _network_builder_error(
+        "delay keys must exactly match the graph edges",
+    )
+    edge_delays = Dict(
+        Edge(Int(edge.src), Int(edge.dst)) => begin
+            delay = delays[edge]
+            delay isa Real && isfinite(delay) && delay >= 0 || _network_builder_error(
+                "delay for $(edge) must be finite and nonnegative",
+            )
+            normalized_delay = try
+                Float64(delay)
+            catch
+                _network_builder_error(
+                    "delay for $(edge) must be representable as a finite Float64",
+                )
+            end
+            isfinite(normalized_delay) || _network_builder_error(
+                "delay for $(edge) must be representable as a finite Float64",
+            )
+            normalized_delay
+        end
+        for edge in edges(graph)
+    )
+
+    validated_node_protocols = _validate_protocol_specifications(node_protocols, :node)
+    validated_link_protocols = _validate_protocol_specifications(link_protocols, :edge)
+
+    topology = SimpleGraph{Int}(graph)
+    registers = [Register(register_args...) for _ in vertices(topology)]
+    all(!isempty, registers) || _network_builder_error(
+        "Register(register_args...) must contain at least one slot",
+    )
+    edge_delay(src, dst) = edge_delays[Edge(minmax(src, dst)...)]
+    network = RegisterNet(
+        topology,
+        registers;
+        classical_delay=edge_delay,
+        quantum_delay=edge_delay,
+    )
+    sim = get_time_tracker(network)
+
+    protocols = ProtocolZoo.AbstractProtocol[]
+    for specification in validated_node_protocols
+        attachment_field = only(values(specification.attachment_fields))
+        for node in vertices(topology)
+            attachment = _attachment_keywords((attachment_field,), (node,))
+            push!(protocols, specification.protocol_type(;
+                sim,
+                net=network,
+                attachment...,
+                specification.configured...,
+            ))
+        end
+    end
+    for specification in validated_link_protocols
+        attachment_fields = Tuple(values(specification.attachment_fields))
+        for (; src, dst) in edges(topology)
+            attachment = _attachment_keywords(attachment_fields, (src, dst))
+            push!(protocols, specification.protocol_type(;
+                sim,
+                net=network,
+                attachment...,
+                specification.configured...,
+            ))
+        end
+    end
+
+    for protocol in protocols
+        @process protocol()
+    end
+    return (; sim, network)
+end

--- a/src/network_builder.jl
+++ b/src/network_builder.jl
@@ -20,14 +20,8 @@ julia> dist_to_delay(Dict(Edge(1, 2) => 100_000_000))[Edge(1, 2)]
 ```
 """
 function dist_to_delay(distance_m::Real, speed_m_per_s::Real=2.0e8)
-    isfinite(distance_m) && distance_m >= 0 || throw(DomainError(
-        distance_m,
-        "distance_m must be finite and nonnegative",
-    ))
-    isfinite(speed_m_per_s) && speed_m_per_s > 0 || throw(DomainError(
-        speed_m_per_s,
-        "speed_m_per_s must be finite and positive",
-    ))
+    @domain isfinite(distance_m) && distance_m ≥ 0
+    @domain isfinite(speed_m_per_s) && speed_m_per_s > 0
     delay = distance_m / speed_m_per_s
     isfinite(delay) || throw(DomainError(
         (distance_m, speed_m_per_s),
@@ -37,10 +31,7 @@ function dist_to_delay(distance_m::Real, speed_m_per_s::Real=2.0e8)
 end
 
 function dist_to_delay(distances::AbstractDict, speed_m_per_s::Real=2.0e8)
-    isfinite(speed_m_per_s) && speed_m_per_s > 0 || throw(DomainError(
-        speed_m_per_s,
-        "speed_m_per_s must be finite and positive",
-    ))
+    @domain isfinite(speed_m_per_s) && speed_m_per_s > 0
     return Dict(edge => dist_to_delay(distance_m, speed_m_per_s) for
                 (edge, distance_m) in distances)
 end

--- a/test/general/network_builder_tests.jl
+++ b/test/general/network_builder_tests.jl
@@ -1,0 +1,183 @@
+using Test
+using ConcurrentSim
+using Graphs
+using QuantumSavory
+using QuantumSavory.ProtocolZoo
+
+Base.@kwdef struct UncatalogedNodeProtocol <: ProtocolZoo.AbstractProtocol
+    sim::Simulation
+    net::RegisterNet
+    node::Int
+end
+
+Base.@kwdef struct InvalidRequiredFieldProtocol <: ProtocolZoo.AbstractProtocol
+    sim::Simulation
+    net::RegisterNet
+    node::Int
+end
+
+ProtocolZoo.protocol_catalog_metadata(::Type{InvalidRequiredFieldProtocol}) = (
+    attachment=:node,
+    attachment_fields=(node=:node,),
+    required_fields=(:missing,),
+)
+
+@testset "Distance to propagation delay" begin
+    @test dist_to_delay(0) == 0.0
+    @test dist_to_delay(4.0e8) == 2.0
+    @test dist_to_delay(3.0e8, 3.0e8) == 1.0
+
+    distances = Dict(Edge(1, 2) => 1.0e8, Edge(2, 3) => 4.0e8)
+    delays = dist_to_delay(distances)
+    @test delays == Dict(Edge(1, 2) => 0.5, Edge(2, 3) => 2.0)
+    @test delays !== distances
+    @test dist_to_delay(distances, 1.0e8) ==
+        Dict(Edge(1, 2) => 1.0, Edge(2, 3) => 4.0)
+
+    for distance in (-1, -Inf, Inf, NaN)
+        @test_throws DomainError dist_to_delay(distance)
+    end
+    for speed in (0, -1, -Inf, Inf, NaN)
+        @test_throws DomainError dist_to_delay(1, speed)
+        @test_throws DomainError dist_to_delay(Dict{Edge{Int},Float64}(), speed)
+    end
+end
+
+@testset "Network builder validates topology and constructs channels" begin
+    graph = path_graph(3)
+    delays = Dict(Edge(1, 2) => 0.25, Edge(2, 3) => 0.75)
+    (; sim, network) = network_builder(graph, delays, (2,))
+
+    @test now(sim) == 0
+    @test nv(network) == 3
+    @test all(register -> length(register) == 2, network[:])
+    @test all(register -> get_time_tracker(register) === sim, network[:])
+    for edge in edges(graph)
+        for (src, dst) in ((edge.src, edge.dst), (edge.dst, edge.src))
+            @test channel(network, src => dst).delay == delays[edge]
+            @test qchannel(network, src => dst).queue.delay == delays[edge]
+        end
+    end
+    graph32 = SimpleGraph{Int32}(graph)
+    delays32 = Dict(edge => big"0.5" for edge in edges(graph32))
+    result32 = network_builder(graph32, delays32, (1,))
+    @test result32.network.graph == graph
+    @test channel(result32.network, 1 => 2).delay == 0.5
+
+    @test_throws ArgumentError network_builder(SimpleGraph(0), Dict(), (1,))
+    @test_throws ArgumentError network_builder(graph, Dict(Edge(1, 2) => 0.1), (1,))
+    @test_throws ArgumentError network_builder(
+        graph,
+        Dict(Edge(1, 2) => 0.1, Edge(2, 3) => 0.1, Edge(1, 3) => 0.1),
+        (1,),
+    )
+    for bad_delay in (-1.0, Inf, NaN, "slow", big(10)^1000)
+        invalid_delays = Dict{Any,Any}(delays)
+        invalid_delays[Edge(1, 2)] = bad_delay
+        @test_throws ArgumentError network_builder(graph, invalid_delays, (1,))
+    end
+    @test_throws ArgumentError network_builder(graph, delays, (0,))
+end
+
+@testset "Network builder validates catalog protocol specifications" begin
+    graph = path_graph(2)
+    delays = Dict(only(edges(graph)) => 0.0)
+
+    @test_throws ArgumentError network_builder(
+        graph,
+        delays,
+        (1,);
+        node_protocols=(Int => (;),),
+    )
+    @test_throws ArgumentError network_builder(
+        graph,
+        delays,
+        (1,);
+        node_protocols=(UncatalogedNodeProtocol => (;),),
+    )
+    @test_throws ArgumentError network_builder(
+        graph,
+        delays,
+        (1,);
+        node_protocols=(InvalidRequiredFieldProtocol => (;),),
+    )
+    @test_throws ArgumentError network_builder(
+        graph,
+        delays,
+        (1,);
+        node_protocols=(SimpleSwitchDiscreteProt => (;),),
+    )
+    @test_throws ArgumentError network_builder(
+        graph,
+        delays,
+        (1,);
+        node_protocols=(EntanglementTracker => (; unknown=true),),
+    )
+    @test_throws ArgumentError network_builder(
+        graph,
+        delays,
+        (1,);
+        node_protocols=(EndNodeController => (; _log=Dict()),),
+    )
+    for configured in ((; sim=Simulation()), (; net=nothing), (; node=1))
+        @test_throws ArgumentError network_builder(
+            graph,
+            delays,
+            (1,);
+            node_protocols=(EntanglementTracker => configured,),
+        )
+    end
+    @test_throws ArgumentError network_builder(
+        graph,
+        delays,
+        (1,);
+        node_protocols=(EntanglerProt => (;),),
+    )
+    @test_throws ArgumentError network_builder(
+        graph,
+        delays,
+        (1,);
+        link_protocols=(EntanglementTracker => (;),),
+    )
+    @test_throws ArgumentError network_builder(
+        graph,
+        delays,
+        (1,);
+        node_protocols=(EntanglementTracker => 1,),
+    )
+end
+
+@testset "Network builder schedules real protocols without running them" begin
+    graph = path_graph(3)
+    delays = Dict(edge => 0.01 for edge in edges(graph))
+    (; sim, network) = network_builder(
+        graph,
+        delays,
+        (2,);
+        node_protocols=(EntanglementTracker => (;),),
+        link_protocols=(EntanglerProt => (;
+            rounds=1,
+            success_prob=1.0,
+            attempt_time=0.1,
+        ),),
+    )
+
+    @test now(sim) == 0
+    @test all(!isassigned(network[node], slot) for node in vertices(graph) for slot in 1:2)
+
+    run(sim, 1.0)
+    for (; src, dst) in edges(graph)
+        source = query(network[src], EntanglementCounterpart, dst, ❓, ❓)
+        @test !isnothing(source)
+        target = query(
+            network[dst],
+            EntanglementCounterpart,
+            src,
+            source.slot.idx,
+            source.tag[4],
+        )
+        @test !isnothing(target)
+        @test observable((source.slot, target.slot), Z ⊗ Z) ≈ 1
+        @test observable((source.slot, target.slot), X ⊗ X) ≈ 1
+    end
+end

--- a/test/general/network_builder_tests.jl
+++ b/test/general/network_builder_tests.jl
@@ -41,6 +41,11 @@ ProtocolZoo.protocol_catalog_metadata(::Type{InvalidRequiredFieldProtocol}) = (
         @test_throws DomainError dist_to_delay(1, speed)
         @test_throws DomainError dist_to_delay(Dict{Edge{Int},Float64}(), speed)
     end
+    @test_throws DomainError dist_to_delay(1.0e308, 1.0e-308)
+    @test_throws DomainError dist_to_delay(
+        Dict(Edge(1, 2) => 1.0e308),
+        1.0e-308,
+    )
 end
 
 @testset "Network builder validates topology and constructs channels" begin


### PR DESCRIPTION
## Summary

- export `dist_to_delay` for scalar and edge-keyed distance conversion with strict validation
- add `network_builder` to construct uniform register networks, configure bidirectional delays, validate protocol specifications through catalog metadata, and schedule node/link protocols
- add integration coverage with real `EntanglementTracker` and `EntanglerProt` protocols
- add an executable ARPANET tutorial and keep CommunicationNetworkDatasets as a docs-only dependency

## Validation

- focused network builder tests: 67/67
- complete `general` shard: 15,102/15,102
- JET: no errors across 1,178 definitions
- plotting doctests: 1/1
- isolated dataset tutorial build and map rendering
- `git diff --check`

## Notes

The credentialed full documentation deployment was left to CI. The tutorial page was executed locally in the docs environment.