### PR TITLE
Fix Mermaid rendering in documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- **(fix)** Restore Mermaid diagram rendering in the documentation.
 - Add finite-Fock homodyne measurement for `QuantumOpticsRepr`.
 - Add `dist_to_delay` and `network_builder` for easily constructing large register networks based on a template.
 - `generate_map` now accepts a custom Tyler tile provider.

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -34,4 +34,5 @@ QuantumSavory = {path = ".."}
 
 [compat]
 CommunicationNetworkDatasets = "0.1"
+DocumenterMermaid = "0.1.1"
 PrettyPrint = "0.2.0"


### PR DESCRIPTION
## Summary

- constrain `DocumenterMermaid` to the 0.1 series so the docs use the working Mermaid 10 runtime
- record the user-facing documentation fix in the changelog

## Root cause

The Markdown fences and generated `<div class="mermaid">` elements are correct. `DocumenterMermaid` 0.2 loads the floating `mermaid@11` CDN URL, which now resolves to Mermaid 11.17.x. Mermaid 11.17.x conflicts with the global AMD `define` installed by Documenter/RequireJS and aborts with `Se.default.extend is not a function` before it replaces the diagram text with SVG. This is the upstream regression tracked in https://github.com/mermaid-js/mermaid/issues/8095.

`DocumenterMermaid` 0.1.1 has the same Documenter integration but loads Mermaid 10, which renders correctly in the existing pages.

## Validation

- reproduced the live failure in headless Chromium: 8 Mermaid blocks, 0 SVGs, `Se.default.extend is not a function`
- verified Mermaid 10 against the live page: 8 Mermaid blocks, 8 SVGs, no Mermaid page error
- built a minimal page with Documenter 1.19.0 and DocumenterMermaid 0.1.1, then verified in headless Chromium: 1 Mermaid block, 1 SVG, 0 page errors
- `git diff --check`

The full repository docs build was not run locally because `docs/make.jl` always invokes the credentialed AnythingLLM integration and deployment path. The Buildkite Docs job is the authoritative full build.