### PR TITLE
docs: name QuantumSavory Studio

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v0.8.0 - 2026-09-05
 
+- Document the GUI under its product name, QuantumSavory Studio.
 - **(breaking)** Standardize `project_traceout!` outcomes: explicit
   orthonormal bases still return one-based indices; an explicit basis plus
   `values` returns `values[index]`; symbolic operators return eigenvalues; and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 ## v0.8.0 - 2026-09-05
 
-- Document the GUI under its product name, QuantumSavory Studio.
 - **(breaking)** Standardize `project_traceout!` outcomes: explicit
   orthonormal bases still return one-based indices; an explicit basis plus
   `values` returns `values[index]`; symbolic operators return eigenvalues; and

--- a/docs/src/api_autodiscovery.md
+++ b/docs/src/api_autodiscovery.md
@@ -2,7 +2,7 @@
 
 QuantumSavory provides runtime catalogs for tools, like GUIs, that need all the models and
 protocols available in the current Julia process. A primary consumer is the
-[QuantumSavory Web GUI](https://gui.quantumsavory.org), developed in the
+[QuantumSavory Studio](https://gui.quantumsavory.org), developed in the
 [WebQuantumSavory repository](https://github.com/QuantumSavory/WebQuantumSavory).
 
 Load the `InteractiveUtils` and `REPL` standard libraries to activate these APIs:

--- a/docs/src/api_autodiscovery.md
+++ b/docs/src/api_autodiscovery.md
@@ -2,8 +2,8 @@
 
 QuantumSavory provides runtime catalogs for tools, like GUIs, that need all the models and
 protocols available in the current Julia process. A primary consumer is the
-[QuantumSavory Studio](https://gui.quantumsavory.org), developed in the
-[WebQuantumSavory repository](https://github.com/QuantumSavory/WebQuantumSavory).
+[QuantumSavory Studio GUI](https://studio.quantumsavory.org), developed in the
+[studio repository](https://github.com/QuantumSavory/QuantumSavoryStudio).
 
 Load the `InteractiveUtils` and `REPL` standard libraries to activate these APIs:
 

--- a/examples/areweentangledyet/public/index.html
+++ b/examples/areweentangledyet/public/index.html
@@ -15,7 +15,7 @@
   <header class="site-header">
     <nav class="site-nav" aria-label="QuantumSavory resources">
       <a href="https://quantumsavory.org/" target="_blank" rel="noopener noreferrer">QuantumSavory.org <span aria-hidden="true">↗</span><span class="visually-hidden"> (opens in a new tab)</span></a>
-      <a href="https://gui.quantumsavory.org/" target="_blank" rel="noopener noreferrer">GUI <span aria-hidden="true">↗</span><span class="visually-hidden"> (opens in a new tab)</span></a>
+      <a href="https://gui.quantumsavory.org/" target="_blank" rel="noopener noreferrer">QuantumSavory Studio <span aria-hidden="true">↗</span><span class="visually-hidden"> (opens in a new tab)</span></a>
       <a href="https://qs.quantumsavory.org/stable/" target="_blank" rel="noopener noreferrer">Package docs <span aria-hidden="true">↗</span><span class="visually-hidden"> (opens in a new tab)</span></a>
       <a href="https://github.com/QuantumSavory/QuantumSavory.jl" target="_blank" rel="noopener noreferrer">GitHub <span aria-hidden="true">↗</span><span class="visually-hidden"> (opens in a new tab)</span></a>
     </nav>
@@ -34,12 +34,12 @@
     <section class="gui-callout" aria-labelledby="web-gui-heading">
       <div>
         <p class="eyebrow">General-purpose tool</p>
-        <h2 id="web-gui-heading">Build networks with the Web GUI</h2>
+        <h2 id="web-gui-heading">Build networks with QuantumSavory Studio</h2>
       </div>
       <div class="gui-callout-copy">
-        <p>The QuantumSavory Web GUI is a general-purpose tool for defining quantum networks and configuring simulations. It is much less customizable than the purpose-built QuantumSavory and Makie applications below, but it provides a quick visual workflow.</p>
-        <p>Download any GUI-defined setup as a pure QuantumSavory.jl script. The exported script is a useful learning resource and a starting point for more advanced custom simulations and web applications.</p>
-        <a class="button primary" href="https://gui.quantumsavory.org/" target="_blank" rel="noopener noreferrer">Open the QuantumSavory Web GUI <span aria-hidden="true">↗</span><span class="visually-hidden"> (opens in a new tab)</span></a>
+        <p>QuantumSavory Studio is a general-purpose tool for defining quantum networks and configuring simulations. It is much less customizable than the purpose-built QuantumSavory and Makie applications below, but it provides a quick visual workflow.</p>
+        <p>Download any setup defined in QuantumSavory Studio as a pure QuantumSavory.jl script. The exported script is a useful learning resource and a starting point for more advanced custom simulations and web applications.</p>
+        <a class="button primary" href="https://gui.quantumsavory.org/" target="_blank" rel="noopener noreferrer">Open QuantumSavory Studio <span aria-hidden="true">↗</span><span class="visually-hidden"> (opens in a new tab)</span></a>
       </div>
     </section>
 

--- a/examples/areweentangledyet/public/index.html
+++ b/examples/areweentangledyet/public/index.html
@@ -15,7 +15,7 @@
   <header class="site-header">
     <nav class="site-nav" aria-label="QuantumSavory resources">
       <a href="https://quantumsavory.org/" target="_blank" rel="noopener noreferrer">QuantumSavory.org <span aria-hidden="true">↗</span><span class="visually-hidden"> (opens in a new tab)</span></a>
-      <a href="https://gui.quantumsavory.org/" target="_blank" rel="noopener noreferrer">QuantumSavory Studio <span aria-hidden="true">↗</span><span class="visually-hidden"> (opens in a new tab)</span></a>
+      <a href="https://studio.quantumsavory.org/" target="_blank" rel="noopener noreferrer">QuantumSavory Studio <span aria-hidden="true">↗</span><span class="visually-hidden"> (opens in a new tab)</span></a>
       <a href="https://qs.quantumsavory.org/stable/" target="_blank" rel="noopener noreferrer">Package docs <span aria-hidden="true">↗</span><span class="visually-hidden"> (opens in a new tab)</span></a>
       <a href="https://github.com/QuantumSavory/QuantumSavory.jl" target="_blank" rel="noopener noreferrer">GitHub <span aria-hidden="true">↗</span><span class="visually-hidden"> (opens in a new tab)</span></a>
     </nav>
@@ -37,7 +37,7 @@
         <h2 id="web-gui-heading">Build networks with QuantumSavory Studio</h2>
       </div>
       <div class="gui-callout-copy">
-        <p>QuantumSavory Studio is a general-purpose tool for defining quantum networks and configuring simulations. It is much less customizable than the purpose-built QuantumSavory and Makie applications below, but it provides a quick visual workflow.</p>
+        <p>QuantumSavory Studio is a general-purpose graphical tool for defining quantum networks and configuring simulations. It is much less customizable than the purpose-built QuantumSavory and Makie applications below, but it provides a quick visual workflow.</p>
         <p>Download any setup defined in QuantumSavory Studio as a pure QuantumSavory.jl script. The exported script is a useful learning resource and a starting point for more advanced custom simulations and web applications.</p>
         <a class="button primary" href="https://gui.quantumsavory.org/" target="_blank" rel="noopener noreferrer">Open QuantumSavory Studio <span aria-hidden="true">↗</span><span class="visually-hidden"> (opens in a new tab)</span></a>
       </div>

--- a/src/ProtocolZoo/ProtocolZoo.jl
+++ b/src/ProtocolZoo/ProtocolZoo.jl
@@ -85,7 +85,7 @@ end
 """
     protocol_catalog_metadata(::Type{<:AbstractProtocol})
 
-Opt a protocol type into [`available_protocol_types`](@ref), to make it available to tools like the GUI WebQuantumSavory.
+Opt a protocol type into [`available_protocol_types`](@ref), to make it available to tools like QuantumSavory Studio.
 
 Independent packages extend this method for their own public protocol types and return
 a named tuple with exactly these fields:
@@ -105,7 +105,7 @@ function protocol_catalog_metadata end
 
 """Return metadata for available protocol types.
 
-Used to make a protocol available to tools like the GUI WebQuantumSavory.
+Used to make a protocol available to tools like QuantumSavory Studio.
 
 The result is sorted by qualified type name. Each entry contains `type`, `doc`,
 `nodeargs`, `attachment`, `attachment_fields`, `parameters`, and

--- a/src/ProtocolZoo/ProtocolZoo.jl
+++ b/src/ProtocolZoo/ProtocolZoo.jl
@@ -85,7 +85,7 @@ end
 """
     protocol_catalog_metadata(::Type{<:AbstractProtocol})
 
-Opt a protocol type into [`available_protocol_types`](@ref), to make it available to tools like QuantumSavory Studio.
+Opt a protocol type into [`available_protocol_types`](@ref), to make it available to tools like the QuantumSavory Studio GUI.
 
 Independent packages extend this method for their own public protocol types and return
 a named tuple with exactly these fields:

--- a/src/backgrounds.jl
+++ b/src/backgrounds.jl
@@ -94,7 +94,7 @@ public available_background_types
 
 """Return the available public background types along with their documentation.
 
-Used to make a background available to tools like the GUI WebQuantumSavory.
+Used to make a background available to tools like QuantumSavory Studio.
 
 Concrete direct and indirect subtypes of [`AbstractBackground`](@ref) are discovered on
 each call. The defining binding of each type must be public. The `InteractiveUtils`

--- a/src/traits_and_defaults.jl
+++ b/src/traits_and_defaults.jl
@@ -17,7 +17,7 @@ public available_slot_types, constructor_metadata
 
 """Return the available public slot types along with their documentation.
 
-Used to make a slot type available to tools like the GUI WebQuantumSavory.
+Used to make a slot type available to tools like QuantumSavory Studio.
 
 Concrete direct and indirect subtypes of [`QuantumStateTrait`](@ref) are discovered on
 each call. The defining binding of each type must be public. The `InteractiveUtils`
@@ -26,7 +26,7 @@ function available_slot_types end
 
 """Return documented constructor fields for a type.
 
-Used to make a constructor available to tools like the GUI WebQuantumSavory.
+Used to make a constructor available to tools like QuantumSavory Studio.
 
 Each entry has the fields `field`, `type`, and `doc`. Undocumented fields and fields
 whose names begin with an underscore are omitted. The `InteractiveUtils` and `REPL`


### PR DESCRIPTION
## Summary

- identify the GUI as QuantumSavory Studio in the runtime-catalog documentation and public docstrings
- update the `examples/areweentangledyet` navigation and callout to use the product name
- retain `WebQuantumSavory` where it identifies the source repository
- record the documentation change in the changelog

## Testing

The complete repository test suite was executed locally:

- [x] focused `plotting/doctests` — 1 test passed
- [x] `general` — 15,231 tests passed
- [x] `example` — 35 tests passed
- [x] `plotting` — passed
- [x] `jet` — executed; the existing `src/ProtocolZoo/switches.jl:174` inference report is the sole failure

The JET failure was reproduced unchanged in a separate worktree at the exact pull-request base commit (`e048ab9a`), confirming that it is unrelated to these documentation-only changes. The CI downgrade failure is also present on the base commit and occurs in dependency precompilation.

The credentialed documentation entry point was not run locally because it updates the external AnythingLLM index and deploys the site. The focused doctest and every local test shard were run instead.

## Review

An independent advanced-agent review found no substantive issues and verified the naming boundary and documentation scope.

- [x] The change is properly formatted.
- [x] The user-facing change is documented.
- [x] The complete local test suite was executed.

