### PR TITLE
Expose weighted State Zoo constructor metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 - Add `dist_to_delay` and `network_builder` for easily constructing large register networks based on a template.
 - `generate_map` now accepts a custom Tyler tile provider.
 - QTCP `LinkController` can now consume pairs from an independent `EntanglerProt` based on reciprocal `(remote_node, remote_slot, pair_id)` tags being present.
+- `constructor_metadata(StatesZoo.BarrettKokBellPairW)` now describes its public
+  convenience-constructor parameters rather than its internal wrapper field.
 
 ## v0.7.2 - 2026-08-15
 

--- a/docs/src/api_autodiscovery.md
+++ b/docs/src/api_autodiscovery.md
@@ -19,7 +19,8 @@ The public, non-exported functions
 `QuantumSavory.available_slot_types` and
 `QuantumSavory.available_background_types` return `(type, doc)` entries.
 `QuantumSavory.constructor_metadata(T)` returns `(field, type, doc)` entries and omits
-undocumented or underscore-prefixed fields.
+undocumented or underscore-prefixed fields. Types with convenience constructors that
+differ from their storage layout can specialize this metadata for those constructors.
 
 The type catalogs recursively discover concrete subtypes from every currently loaded
 package and retain usable parametric constructors. A type is included only when its

--- a/ext/QuantumSavoryInteractiveUtils/QuantumSavoryInteractiveUtils.jl
+++ b/ext/QuantumSavoryInteractiveUtils/QuantumSavoryInteractiveUtils.jl
@@ -67,6 +67,10 @@ function QuantumSavory.constructor_metadata(::Type{T}) where {T}
     ]
 end
 
+QuantumSavory.constructor_metadata(
+    ::Type{QuantumSavory.StatesZoo.BarrettKokBellPairW},
+) = QuantumSavory.constructor_metadata(QuantumSavory.StatesZoo.BarrettKokBellPair)
+
 function metadata_error(T, message)
     throw(ArgumentError(
         "invalid protocol catalog metadata for $(_qualified_type_name(T)): $(message)",

--- a/test/general/interactiveutils_tests.jl
+++ b/test/general/interactiveutils_tests.jl
@@ -21,6 +21,19 @@ using REPL
         @test !isempty(QuantumSavory.constructor_metadata(entry.type))
     end
 
+    state_types = (
+        QuantumSavory.StatesZoo.BarrettKokBellPair,
+        QuantumSavory.StatesZoo.BarrettKokBellPairW,
+        QuantumSavory.StatesZoo.DepolarizedBellPair,
+        QuantumSavory.StatesZoo.Genqo.GenqoMultiplexedCascadedBellPairW,
+        QuantumSavory.StatesZoo.Genqo.GenqoUnheraldedSPDCBellPairW,
+    )
+    for state_type in state_types
+        metadata = QuantumSavory.constructor_metadata(state_type)
+        documented_fields = Set(entry.field for entry in metadata if !isempty(string(entry.doc)))
+        @test all(in(documented_fields), QuantumSavory.StatesZoo.stateparameters(state_type))
+    end
+
     for protocol in protocols
         @test all(parameter -> !isnothing(parameter.doc), protocol.parameters)
     end


### PR DESCRIPTION
## Summary

- delegate weighted Barrett–Kok constructor metadata to its public unweighted constructor
- verify every exposed State Zoo parameter has nonempty constructor metadata
- document specialization for convenience constructors with nonmatching storage layouts

## Test

- `julia --project=. -e 'using Pkg; Pkg.test(; test_args=["general/interactiveutils"])'` (49/49 passed)

## Motivation

WebQuantumSavory renders State Zoo constructor parameter documentation from `QuantumSavory.constructor_metadata`. `BarrettKokBellPairW` exposes the unweighted constructor parameters but stores only an internal wrapper field, so generic field metadata cannot describe its public controls.