### PR TITLE
Fix SimpleSwitchDiscreteProt JET inference

### DIFF
--- a/src/ProtocolZoo/switches.jl
+++ b/src/ProtocolZoo/switches.jl
@@ -164,7 +164,7 @@ $TYPEDFIELDS
         length(clientnodes),
         length(clientnodes),
     ))
-    function SimpleSwitchDiscreteProt(sim, net, switchnode, clientnodes, success_probs, ticktock, rounds, assignment_algorithm, _backlog)
+    function SimpleSwitchDiscreteProt(sim, net::RegisterNet, switchnode, clientnodes, success_probs, ticktock, rounds, assignment_algorithm, _backlog)
         length(unique(clientnodes)) == length(clientnodes) || throw(ArgumentError("In the preparation of `SimpleSwitchDiscreteProt` switch protocol, the requested `clientnodes` must be unique!"))
         all(in(neighbors(net, switchnode)), clientnodes) || throw(ArgumentError("In the preparation of `SimpleSwitchDiscreteProt` switch protocol, the requested `clientnodes` must be directly connected to the `switchnode`!"))
         0 < ticktock || throw(ArgumentError("In the preparation of `SimpleSwitchDiscreteProt` switch protocol, the requested protocol period `ticktock` must be positive!"))


### PR DESCRIPTION
## Summary

- Constrain the `SimpleSwitchDiscreteProt` inner constructor network argument to `RegisterNet`.
- Match the constructor contract to the existing concrete field type.
- Eliminate the impossible graph-interface conversion path reported by JET.

## Investigation

The last passing JET build and the first failing build used Julia 1.12.7 and JET 0.12.1, so this is not a JET version regression. The sole report inferred `net` as `Union{AbstractCartesianGrid, AbstractGraph}` after the `neighbors` call, then flagged conversion into the concrete `RegisterNet` field.

I reproduced that exact report locally. Reordering the newer network-builder keyword splats did not affect it and was reverted. Adding the type contract at the inner constructor clears the package-wide analysis.

Failing CI evidence: https://buildkite.com/quantumsavory/quantumsavory-dot-jl/builds/1794#01a071e7-bbb8-4130-98e8-ce70d801fd43

## Validation

- [x] `JULIA_NUM_THREADS=auto julia --startup-file=no --project=. -e 'using Pkg; Pkg.test(; test_args=["jet"])'` — 1/1 passed; 1,194 definitions analyzed; no errors detected
- [x] `JULIA_NUM_THREADS=auto julia --startup-file=no --project=. -e 'using Pkg; Pkg.test(; test_args=["general/protocolzoo_switch", "general/network_builder"])'` — 88/88 passed
- [x] `JULIA_CPU_THREADS=5 JULIA_NUM_THREADS=5 julia --startup-file=no --project=. -e 'using Pkg; Pkg.test(; test_args=["general"])'` — 15,231/15,231 passed

No changelog entry: this is an internal type/inference correction and valid constructor calls are unchanged.