### PR TITLE
docs: update QuantumSavory Studio URL

### DIFF
--- a/examples/areweentangledyet/public/index.html
+++ b/examples/areweentangledyet/public/index.html
@@ -39,7 +39,7 @@
       <div class="gui-callout-copy">
         <p>QuantumSavory Studio is a general-purpose graphical tool for defining quantum networks and configuring simulations. It is much less customizable than the purpose-built QuantumSavory and Makie applications below, but it provides a quick visual workflow.</p>
         <p>Download any setup defined in QuantumSavory Studio as a pure QuantumSavory.jl script. The exported script is a useful learning resource and a starting point for more advanced custom simulations and web applications.</p>
-        <a class="button primary" href="https://gui.quantumsavory.org/" target="_blank" rel="noopener noreferrer">Open QuantumSavory Studio <span aria-hidden="true">↗</span><span class="visually-hidden"> (opens in a new tab)</span></a>
+        <a class="button primary" href="https://studio.quantumsavory.org/" target="_blank" rel="noopener noreferrer">Open QuantumSavory Studio <span aria-hidden="true">↗</span><span class="visually-hidden"> (opens in a new tab)</span></a>
       </div>
     </section>
 


### PR DESCRIPTION
## Summary

- update the QuantumSavory Studio button in `examples/areweentangledyet` to https://studio.quantumsavory.org/
- keep the change limited to a file touched by the merged naming PR #570

## Testing

Not run, per request. This is a text-only link update. `git diff --check` and a scoped stale-URL audit pass.

