### PR TITLE
Improve API docstring structure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,5 @@
 # News
 
-## Unreleased
-
-- Improve API docstring summaries and signatures.
-
 ## v0.8.0 - 2026-09-05
 
 - **(breaking)** Standardize `project_traceout!` outcomes: explicit
@@ -19,6 +15,7 @@
 - QTCP `LinkController` can now consume pairs from an independent `EntanglerProt` based on reciprocal `(remote_node, remote_slot, pair_id)` tags being present.
 - `constructor_metadata(StatesZoo.BarrettKokBellPairW)` now describes its public
   convenience-constructor parameters rather than its internal wrapper field.
+- Improve API docstring summaries and signatures.
 
 ## v0.7.2 - 2026-08-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # News
 
+## Unreleased
+
+- Improve API docstring summaries and signatures.
+
 ## v0.8.0 - 2026-09-05
 
 - **(breaking)** Standardize `project_traceout!` outcomes: explicit

--- a/src/ProtocolZoo/ProtocolZoo.jl
+++ b/src/ProtocolZoo/ProtocolZoo.jl
@@ -192,10 +192,10 @@ Tag(tag::EntanglementHistory) = Tag(EntanglementHistory, tag.remote_node, tag.re
 """
 $TYPEDEF
 
-This tag updates entanglement information and applies an `X` correction after a remote swap.
+This tag updates entanglement information after a remote swap.
 
 This tag arrives as a message from a remote node to which the current node was entangled to update the
-entanglement information and apply an `X` correction after the remote node performs an entanglement swap.
+entanglement information and apply a `Z` correction after the remote node performs an entanglement swap.
 
 $TYPEDFIELDS
 """
@@ -224,10 +224,10 @@ Tag(tag::EntanglementUpdateX) = Tag(EntanglementUpdateX, tag.target_pair_id, tag
 """
 $TYPEDEF
 
-This tag updates entanglement information and applies a `Z` correction after a remote swap.
+This tag updates entanglement information after a remote swap.
 
 This tag arrives as a message from a remote node to which the current node was entangled to update the
-entanglement information and apply a `Z` correction after the remote node performs an entanglement swap.
+entanglement information and apply an `X` correction after the remote node performs an entanglement swap.
 
 $TYPEDFIELDS
 """

--- a/src/ProtocolZoo/ProtocolZoo.jl
+++ b/src/ProtocolZoo/ProtocolZoo.jl
@@ -192,6 +192,8 @@ Tag(tag::EntanglementHistory) = Tag(EntanglementHistory, tag.remote_node, tag.re
 """
 $TYPEDEF
 
+This tag updates entanglement information and applies an `X` correction after a remote swap.
+
 This tag arrives as a message from a remote node to which the current node was entangled to update the
 entanglement information and apply an `X` correction after the remote node performs an entanglement swap.
 
@@ -221,6 +223,8 @@ Tag(tag::EntanglementUpdateX) = Tag(EntanglementUpdateX, tag.target_pair_id, tag
 
 """
 $TYPEDEF
+
+This tag updates entanglement information and applies a `Z` correction after a remote swap.
 
 This tag arrives as a message from a remote node to which the current node was entangled to update the
 entanglement information and apply a `Z` correction after the remote node performs an entanglement swap.
@@ -345,7 +349,11 @@ protocol_catalog_metadata(::Type{EntanglerProt}) = (
     required_fields = (),
 )
 
-"""Convenience constructor for specifying `rate` of generation instead of success probability and time"""
+"""
+$TYPEDSIGNATURES
+
+Convenience constructor for specifying `rate` of generation instead of success probability and time
+"""
 function EntanglerProt(sim::Simulation, net::RegisterNet, nodeA::Int, nodeB::Int; rate::Union{Nothing,Float64}=nothing, kwargs...)
     if isnothing(rate)
         return EntanglerProt(;sim, net, nodeA, nodeB, kwargs...)

--- a/src/ProtocolZoo/entanglement_ids.jl
+++ b/src/ProtocolZoo/entanglement_ids.jl
@@ -12,6 +12,8 @@ const NO_ENTANGLEMENT_ID = zero(EntanglementID)
     EntanglementID(reinterpret(UInt, id) & _ENTANGLEMENT_ID_MASK)
 
 """
+$TYPEDSIGNATURES
+
 Generate a random nonzero entanglement ID.
 """
 function fresh_entanglement_id()
@@ -23,6 +25,8 @@ function fresh_entanglement_id()
 end
 
 """
+$TYPEDSIGNATURES
+
 Combine two entanglement IDs into a new one.
 
 The combiner is modular addition over the nonnegative `Int` range. It is

--- a/src/ProtocolZoo/qtcp.jl
+++ b/src/ProtocolZoo/qtcp.jl
@@ -25,6 +25,8 @@ export QDatagram, Flow,
 """
 $TYPEDEF
 
+Describes a flow that requests entangled pairs between two nodes.
+
 $TYPEDFIELDS
 """
 @kwdef struct Flow <: AbstractTag
@@ -43,6 +45,8 @@ Tag(tag::Flow) = Tag(Flow, tag.src, tag.dst, tag.npairs, tag.uuid) # TODO automa
 
 """
 $TYPEDEF
+
+Marks an entangled pair at the source of a QTCP flow.
 
 $TYPEDFIELDS
 """
@@ -67,6 +71,8 @@ Tag(tag::QTCPPairBegin) = Tag(QTCPPairBegin, tag.flow_uuid, tag.flow_src, tag.fl
 """
 $TYPEDEF
 
+Marks an entangled pair at the destination of a QTCP flow.
+
 $TYPEDFIELDS
 """
 @kwdef struct QTCPPairEnd <: AbstractTag
@@ -89,6 +95,8 @@ Tag(tag::QTCPPairEnd) = Tag(QTCPPairEnd, tag.flow_uuid, tag.flow_src, tag.flow_d
 
 """
 $TYPEDEF
+
+Carries QTCP flow metadata and Pauli-frame corrections toward a destination.
 
 $TYPEDFIELDS
 """
@@ -128,6 +136,8 @@ Tag(tag::QDatagramSuccess) = Tag(QDatagramSuccess, tag.flow_uuid, tag.seq_num, t
 """
 $TYPEDEF
 
+Requests link-level entanglement with a neighboring node for a QTCP datagram.
+
 $TYPEDFIELDS
 """
 @kwdef struct LinkLevelRequest <: AbstractTag
@@ -143,6 +153,8 @@ Tag(tag::LinkLevelRequest) = Tag(LinkLevelRequest, tag.flow_uuid, tag.seq_num, t
 
 """
 $TYPEDEF
+
+Reports link-level entanglement at the requesting node.
 
 $TYPEDFIELDS
 """
@@ -160,6 +172,8 @@ Tag(tag::LinkLevelReply) = Tag(LinkLevelReply, tag.flow_uuid, tag.seq_num, tag.m
 """
 $TYPEDEF
 
+Records the source-side memory slot for an in-progress QTCP pair.
+
 $TYPEDFIELDS
 """
 @kwdef struct LinkLevelReplyAtSource <: AbstractTag
@@ -175,6 +189,8 @@ Tag(tag::LinkLevelReplyAtSource) = Tag(LinkLevelReplyAtSource, tag.flow_uuid, ta
 
 """
 $TYPEDEF
+
+Records the destination-side memory slot for a completed link-level request.
 
 $TYPEDFIELDS
 """

--- a/src/ProtocolZoo/switches.jl
+++ b/src/ProtocolZoo/switches.jl
@@ -129,6 +129,8 @@ end
 """
 $TYPEDEF
 
+This protocol connects pairs of clients through a discrete-time switch controller.
+
 A switch "controller", running on a given node, checking for connection requests
 from neighboring clients, and attempting to serve them by attempting direct raw entanglement
 with the clients and then mediating swaps to connect two clients together.

--- a/src/StatesZoo/barrett_kok.jl
+++ b/src/StatesZoo/barrett_kok.jl
@@ -28,7 +28,11 @@ See also [`BarrettKokBellPairW`](@ref) for the weighted density matrix.
     m
 end
 
-"""The weighted version of [`BarrettKokBellPair`](@ref), i.e. its trace is the probability of successfully heralding a Barrett-Kok Bell pair."""
+"""
+$TYPEDEF
+
+The weighted version of [`BarrettKokBellPair`](@ref), i.e. its trace is the probability of successfully heralding a Barrett-Kok Bell pair.
+"""
 @withmetadata struct BarrettKokBellPairW <: AbstractTwoQubitState
     bkbp::BarrettKokBellPair
 end

--- a/src/StatesZoo/state_explorer.jl
+++ b/src/StatesZoo/state_explorer.jl
@@ -1,6 +1,9 @@
 # implemented in Makie extension
 
-"""An interactive explorer for two-qubit states. It returns a new figure.
+"""
+    stateexplorer(S)
+
+An interactive explorer for two-qubit states. It returns a new figure.
 
 Requires a Makie plotting backend to be imported.
 

--- a/src/backgrounds.jl
+++ b/src/backgrounds.jl
@@ -69,7 +69,7 @@ end
 """
 $TYPEDEF
 
-A depolarization background.
+An amplitude-damping background.
 """
 @kwdef struct AmplitudeDamping <: AbstractBackground
     "The characteristic time of the amplitude damping process."

--- a/src/backgrounds.jl
+++ b/src/backgrounds.jl
@@ -1,4 +1,8 @@
-"""A background describing the T₁ decay of a two-level system."""
+"""
+$TYPEDEF
+
+A background describing the T₁ decay of a two-level system.
+"""
 @kwdef struct T1Decay <: AbstractBackground
     "The T₁ time of the two-level system."
     t1::Float64 = 1e9 # TODO consider parameterizing the type
@@ -10,7 +14,11 @@
     end
 end
 
-"""A background describing the T₂ dephasing of a two-level system."""
+"""
+$TYPEDEF
+
+A background describing the T₂ dephasing of a two-level system.
+"""
 @kwdef struct T2Dephasing <: AbstractBackground
     "The T₂ time of the two-level system."
     t2::Float64 = 1e9 # TODO consider parameterizing the type
@@ -58,7 +66,11 @@ end
     end
 end
 
-"""A depolarization background."""
+"""
+$TYPEDEF
+
+A depolarization background.
+"""
 @kwdef struct AmplitudeDamping <: AbstractBackground
     "The characteristic time of the amplitude damping process."
     τ::Float64 = 1e9 # TODO consider parameterizing the type

--- a/src/baseops/apply.jl
+++ b/src/baseops/apply.jl
@@ -1,4 +1,6 @@
 """
+$TYPEDSIGNATURES
+
 Apply a given operation on the given set of register slots.
 
 `apply!([regA, regB], [slot1, slot2], Gates.CNOT)` would apply a CNOT gate

--- a/src/baseops/initialize.jl
+++ b/src/baseops/initialize.jl
@@ -21,6 +21,8 @@ end
 initialize!(r::RegRef; time=nothing) = initialize!(r.reg, r.idx; time)
 
 """
+$TYPEDSIGNATURES
+
 Set the state of a given set of registers.
 
 `initialize!([regA,regB], [slot1,slot2], state)` would

--- a/src/baseops/observable.jl
+++ b/src/baseops/observable.jl
@@ -1,4 +1,6 @@
 """
+$TYPEDSIGNATURES
+
 Calculate the expectation value of a quantum observable on the given register and slot.
 
 `observable([regA, regB], [slot1, slot2], obs)` would calculate the expectation value

--- a/src/baseops/traceout.jl
+++ b/src/baseops/traceout.jl
@@ -54,6 +54,8 @@ function traceout!(s::StateRef, i::Int)
 end
 
 """
+$TYPEDSIGNATURES
+
 Delete one or more register slots.
 
 `traceout!(reg, slot)` would reset (perform a partial trace) over the given subsystem.

--- a/src/baseops/uptotime.jl
+++ b/src/baseops/uptotime.jl
@@ -1,4 +1,6 @@
 """
+    uptotime!
+
 Evolve all the states in a register to a given time, according to the various backgrounds that they might have.
 
 ```jldoctest

--- a/src/messagebuffer.jl
+++ b/src/messagebuffer.jl
@@ -1,4 +1,6 @@
 """
+$TYPEDEF
+
 A a buffer for classical messages. Usually a part of a [`Register`](@ref) structure.
 
 See also: [`channel`](@ref), [`messagebuffer`](@ref)
@@ -180,6 +182,8 @@ function Base.wait(mb::MessageBuffer)
 end
 
 """
+    onchange
+
 Wait for changes to occur on a [`MessageBuffer`](@ref) or [`Register`](@ref). By specifying a second argument, you can filter what type of events are waited on.
 E.g. `onchange(r, Tag)` will wait only on changes to tags and metadata.
 """

--- a/src/networks.jl
+++ b/src/networks.jl
@@ -120,6 +120,8 @@ function RegisterNet(graph::SimpleGraph, registers, vertex_metadata, edge_metada
 end
 
 """
+$TYPEDSIGNATURES
+
 Construct a [`RegisterNet`](@ref) from a given list of [`Register`](@ref)s and a graph.
 
 The `classical_delay` and `quantum_delay` keyword arguments each accept either a
@@ -156,7 +158,10 @@ empty_vmd(n) = [Dict{Symbol,Any}() for _ in 1:n]
 empty_emd()  = Dict{Tuple{Int,Int},Dict{Symbol,Any}}()
 empty_demd() = Dict{Pair{Int,Int},Dict{Symbol,Any}}()
 
-"""Construct a [`RegisterNet`](@ref) from a given list of [`Register`](@ref)s, defaulting to a chain topology.
+"""
+$TYPEDSIGNATURES
+
+Construct a [`RegisterNet`](@ref) from a given list of [`Register`](@ref)s, defaulting to a chain topology.
 
 ```jldoctest
 julia> net = RegisterNet([Register(2), Register(4), Register(2)])
@@ -191,7 +196,10 @@ parentindex(r::Register) = r.netindex[]
 
 ## Channel accessors
 
-"""Get a handle to a classical channel between two registers.
+"""
+$TYPEDSIGNATURES
+
+Get a handle to a classical channel between two registers.
 
 Usually used for sending classical messages between registers.
 It can be used for receiving as well, but a more convenient choice is [`messagebuffer`](@ref),
@@ -217,7 +225,10 @@ function channel(net::RegisterNet, args...; permit_forward=false)
     return achannel(net, args..., Val{:C}(); permit_forward)
 end
 
-"""Get a handle to a quantum channel between two registers.
+"""
+$TYPEDSIGNATURES
+
+Get a handle to a quantum channel between two registers.
 
 ```jldoctest
 julia> net = RegisterNet([Register(2), Register(2), Register(2)]) # defaults to a chain topology

--- a/src/noninstant.jl
+++ b/src/noninstant.jl
@@ -1,6 +1,10 @@
 abstract type AbstractNoninstantOperation end
 
-"""Represents an gate applied instantaneously followed by a waiting period. See also [`ConstantHamiltonianEvolution`](@ref)."""
+"""
+$TYPEDEF
+
+Represents an gate applied instantaneously followed by a waiting period. See also [`ConstantHamiltonianEvolution`](@ref).
+"""
 struct NonInstantGate <: AbstractNoninstantOperation
     gate
     duration # TODO assert larger than zero
@@ -12,7 +16,11 @@ function apply!(regs::Vector{Register}, indices::Base.AbstractVecOrTuple{Int}, o
     regs, new_time+operation.duration
 end
 
-"""Represents a Hamiltonian being applied for the given duration. See also [`NonInstantGate`](@ref)."""
+"""
+$TYPEDEF
+
+Represents a Hamiltonian being applied for the given duration. See also [`NonInstantGate`](@ref).
+"""
 struct ConstantHamiltonianEvolution <: AbstractNoninstantOperation
     hamiltonian
     duration # TODO assert larger than zero

--- a/src/plots.jl
+++ b/src/plots.jl
@@ -17,7 +17,7 @@ Requires a Makie backend be already imported."""
 function registernetplot_axis end
 
 """
-    resourceplot_axis(subfig, network, edgeresources, vertexresources; kwargs...)
+    resourceplot_axis(subfig, network, edgeresources, vertexresources; registercoords=nothing, title="")
 
 Draw the various resources and locks stored in the given meta-graph on a given Makie axis.
 

--- a/src/plots.jl
+++ b/src/plots.jl
@@ -8,12 +8,18 @@ function registernetplot end
 Requires a Makie backend be already imported."""
 function registernetplot! end
 
-"""Draw the given register network on a given Makie axis or subfigure and modify the axis with numerous visualization enhancements.
+"""
+    registernetplot_axis(registersobservable; kwargs...)
+
+Draw the given register network on a given Makie axis or subfigure and modify the axis with numerous visualization enhancements.
 
 Requires a Makie backend be already imported."""
 function registernetplot_axis end
 
-"""Draw the various resources and locks stored in the given meta-graph on a given Makie axis.
+"""
+    resourceplot_axis(subfig, network, edgeresources, vertexresources; kwargs...)
+
+Draw the various resources and locks stored in the given meta-graph on a given Makie axis.
 
 Requires a Makie backend be already imported."""
 function resourceplot_axis end
@@ -23,7 +29,10 @@ function showmetadata end
 
 function showonplot end
 
-"""Generates a default map with country and state boundaries and returns a GeoAxis. The returned GeoAxis can be used as an input for registernetplot_axis.
+"""
+    generate_map([subfig]; extent=nothing, provider=TileProviders.OpenStreetMap())
+
+Generates a default map with country and state boundaries and returns a GeoAxis. The returned GeoAxis can be used as an input for registernetplot_axis.
 
 The `Tyler` package must be installed and imported."""
 function generate_map end

--- a/src/quantumchannel.jl
+++ b/src/quantumchannel.jl
@@ -1,4 +1,6 @@
 """
+$TYPEDEF
+
 Quantum channel for transmitting quantum states from one register to another.
 
 Delay and background noise processes are supported.

--- a/src/queries.jl
+++ b/src/queries.jl
@@ -62,13 +62,19 @@ struct Wildcard end
 
 const QueryTypes = Union{Function,Wildcard,TagElementTypes}
 
-"""A wildcard instance for use with the tag querying functionality.
+"""
+    W
+
+A wildcard instance for use with the tag querying functionality.
 
 See also: [`query`](@ref), [`tag!`](@ref), [`❓`](@ref)"""
 const W = Wildcard()
 
 
-"""A wildcard instance for use with the tag querying functionality.
+"""
+    ❓
+
+A wildcard instance for use with the tag querying functionality.
 
 This emoji can be inputted with the `\\:question:` emoji shortcut,
 or you can simply use the ASCII alternative [`W`](@ref).
@@ -489,7 +495,10 @@ end
 
 alwaystrue(x) = true
 
-"""Find an empty unlocked slot in a given [`Register`](@ref).
+"""
+$TYPEDSIGNATURES
+
+Find an empty unlocked slot in a given [`Register`](@ref).
 
 ```jldoctest
 julia> reg = Register(3); initialize!(reg[1], X); lock(reg[2]);

--- a/src/querywait.jl
+++ b/src/querywait.jl
@@ -1,5 +1,6 @@
 """
-$TYPEDSIGNATURES
+    query_wait(store::Register, args...; on::Type{On}=Any, locked::Union{Nothing,Bool}=nothing, assigned::Union{Nothing,Bool}=nothing) where {On}
+    query_wait(store::MessageBuffer, args...; on::Type{On}=Any) where {On}
 
 A convenience function that combines waiting (via [`onchange`](@ref)) and querying (via [`query`](@ref)) in a loop,
 returning a ConcurrentSim process that yields the first successful query result.
@@ -117,7 +118,10 @@ function query_wait(store::MessageBuffer, args...; on::Type{On}=Any) where {On}
 end
 
 """
-$TYPEDSIGNATURES
+    querydelete_wait!(store::Register, args...; on::Type{On}=Any, locked::Union{Nothing,Bool}=nothing, assigned::Union{Nothing,Bool}=nothing) where {On}
+    querydelete_wait!(store::MessageBuffer, args...; on::Type{On}=Any) where {On}
+
+Wait for and remove the first tag matching a query.
 
 A convenience function that combines waiting (via [`onchange`](@ref)) and querying-with-deletion (via [`querydelete!`](@ref)) in a loop,
 returning a ConcurrentSim process that yields the first successful query result (deleting the matched entry).

--- a/src/states_registers.jl
+++ b/src/states_registers.jl
@@ -10,6 +10,8 @@ end
 StateRef(state, registers, registerindices) = StateRef(Ref{Any}(copy(state)), registers, registerindices) # TODO same as above, this should not be forced to Any
 
 """
+$TYPEDEF
+
 The main data structure in `QuantumSavory`, used to represent a quantum register in an arbitrary formalism.
 """
 struct Register # TODO better type description / TODO mutable struct with immutable fields to remove the refs
@@ -52,6 +54,8 @@ Register(nqubits::Int,repr::AbstractRepresentation) = Register(fill(Qubit(),nqub
 Register(nqubits::Int,bg::AbstractBackground) = Register(fill(Qubit(),nqubits),fill(bg,nqubits))
 
 """
+$TYPEDEF
+
 A reference to a [`Register`](@ref) slot, convenient for use with functions like [`apply!`](@ref), etc.
 
 ```jldoctest

--- a/src/tags.jl
+++ b/src/tags.jl
@@ -22,6 +22,8 @@ struct MyTag <: AbstractTag end
 abstract type AbstractTag end
 
 """
+$TYPEDEF
+
 Tags are used to represent classical metadata describing the state (or even history) of nodes and their registers. The library allows the construction of custom tags using the `Tag` constructor. Currently tags are implemented as instances of a [sum type](https://github.com/MasonProtter/SumTypes.jl) and have fairly constrained structure. Most of them are constrained to contain only Symbol instances and integers.
 
 Here is an example of such a generic tag:

--- a/src/traits_and_defaults.jl
+++ b/src/traits_and_defaults.jl
@@ -4,9 +4,17 @@ abstract type QuantumStateTrait end
 """An abstract type for the various background processes that might be inflicted upon a [`Register`](@ref) slot, e.g. decay, dephasing, etc."""
 abstract type AbstractBackground end
 
-"""Specifies that a given register slot contains qubits."""
+"""
+$TYPEDEF
+
+Specifies that a given register slot contains qubits.
+"""
 struct Qubit <: QuantumStateTrait end
-"""Specifies that a given register slot contains qumodes."""
+"""
+$TYPEDEF
+
+Specifies that a given register slot contains qumodes.
+"""
 struct Qumode <: QuantumStateTrait end
 
 # TODO move these definitions to a neater place


### PR DESCRIPTION
## Summary

- add leading API signatures to the audited QuantumSavory docstrings
- add short purpose summaries where audited type docstrings had no prose
- split overlong opening sentences while preserving their detailed text
- use DocStringExtensions placeholders wherever binding metadata permits

This branch is based directly on `master` and does not include the DocumenterCodeBlocks builder or dependency changes from #569.

## Validation

- full isolated docs build with DocumenterCodeBlocks 1.5.0: pass, with 0 QuantumSavory-owned warnings
- `Pkg.test(; test_args=["plotting/doctests"])`: pass
- Julia parser checks for every changed source file: pass
- `git diff --check`: pass
- independent maintainer review: no findings after follow-up corrections
- Linux Julia CI, changelog, spelling, and CodeQL checks: pass; remaining hosted checks are still running

The isolated build still reports 36 dependency-owned diagnostics (33 QuantumSymbolics and 3 QuantumInterface), which are intentionally outside this PR.