### PR TITLE
Treat unmentioned trailing tag fields as query wildcards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # News
 
+## Unreleased
+
+- `query` now treats the fields a query does not mention as trailing wildcards, so a query shorter than the tag matches on the fields it does specify.
+
 ## v0.8.0 - 2026-09-05
 
 - **(breaking)** Standardize `project_traceout!` outcomes: explicit

--- a/docs/src/tag_query.md
+++ b/docs/src/tag_query.md
@@ -87,6 +87,13 @@ query(reg, EntanglementCounterpart, 7, ❓, ❓)
 query(reg, :score, x -> x > 90)
 ```
 
+Fields the query does not mention are wildcards too, so a query shorter than the
+tag matches on the fields it does specify.
+
+```julia
+query(reg, EntanglementCounterpart, 7)
+```
+
 This is the part that makes the metadata plane flexible. Protocols can agree on
 the meaning of a tag without agreeing on one exact hard-coded lookup path.
 

--- a/src/queries.jl
+++ b/src/queries.jl
@@ -311,9 +311,8 @@ for i in 1:10
         signature = methods(variant)[1].sig.parameters[2:end]
         l = length(signature)
         sigargs = VARS[1:l]
-        if l==i
+        if l>=i # a query shorter than the tag leaves the trailing fields as implicit wildcards
             push!(cases, :($symbol($(sigargs...)) => $composite_check))
-        else
         end
     end
     body_expr = isempty(cases) ? :(false) : quote

--- a/test/general/tags_and_queries_tests.jl
+++ b/test/general/tags_and_queries_tests.jl
@@ -209,6 +209,22 @@ lock(reg[3])
 @test findfreeslot(reg, chooseslot=3) == nothing
 @test findfreeslot(reg, chooseslot=3, locked=true).idx == 3
 
+##
+
+reg = Register(4)
+tag!(reg[1], EntanglementCounterpart, 5, 11)
+tag!(reg[2], :symbol1, 7, 8)
+
+@test strip_id(query(reg, EntanglementCounterpart, 5)) == (slot = reg[1], tag = Tag(EntanglementCounterpart, 5, 11))
+@test strip_id(query(reg, EntanglementCounterpart)) == (slot = reg[1], tag = Tag(EntanglementCounterpart, 5, 11))
+@test query(reg, EntanglementCounterpart, 5) == query(reg, EntanglementCounterpart, 5, ❓)
+@test query(reg, EntanglementCounterpart) == query(reg, EntanglementCounterpart, ❓, ❓)
+@test query(reg, EntanglementCounterpart, 6) === nothing
+@test strip_id(query(reg, :symbol1, 7)) == (slot = reg[2], tag = Tag(:symbol1, 7, 8))
+@test strip_id(query(reg, :symbol1)) == (slot = reg[2], tag = Tag(:symbol1, 7, 8))
+@test query(reg, :symbol2) === nothing
+@test length(queryall(reg, EntanglementCounterpart)) == 1
+
 end
 
 f()


### PR DESCRIPTION
#194 is assigned to @hanakl. If they are on it, close this.

`query` builds its matcher per argument count, and a tag variant only gets a match case when its field count equals the number of query arguments. Everything else falls through to `false`, so a query shorter than the tag matches nothing instead of matching on the fields it does specify.

```julia
reg = Register(4)
tag!(reg[1], EntanglementCounterpart, 5, 11)

query(reg, EntanglementCounterpart, 5, 11)  # matches
query(reg, EntanglementCounterpart, 5, ❓)  # matches
query(reg, EntanglementCounterpart, 5)      # nothing, on master
query(reg, EntanglementCounterpart)         # nothing, on master
```

The generated pattern already binds every field of the variant while the check only looks at the leading ones, so the trailing bindings act as wildcards on their own. Relaxing `l==i` to `l>=i` is the whole change.

Reverting `src/queries.jl` and keeping the test gives 89 passing and 7 failing, against 96 with it. `query(reg, EntanglementCounterpart, 6)` and `query(reg, :symbol2)` still return `nothing` either way.

`EntanglementConsumer` still branches on the tag type, since it also decides whether to read `pair_id` from field 4. Happy to do that separately.

Closes #194.

- [x] The code is properly formatted and commented.
- [x] Substantial new functionality is documented within the docs.
- [x] All new functionality is tested.
- [ ] All of the automated tests on github pass. Workflows need maintainer approval before they run, so this is not verified here yet. Locally the `general` suite is 15245 passing on Julia 1.12.
- [x] We recently started enforcing formatting checks. If formatting issues are reported in the new code you have written, please correct them.
