### PR TITLE
Add a BBM92 entanglement-based key distribution protocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # News
 
+## Unreleased
+
+- Add `BBM92Prot`, an entanglement-based quantum key distribution protocol, with `sifted_key` and `qber` for reading its rounds. It can be run against an intercept-resend eavesdropper.
+
 ## v0.8.0 - 2026-09-05
 
 - **(breaking)** Standardize `project_traceout!` outcomes: explicit

--- a/docs/src/API_ProtocolZoo.md
+++ b/docs/src/API_ProtocolZoo.md
@@ -105,6 +105,7 @@ The current `ProtocolZoo` includes:
 - entanglement generation and swapping protocols,
 - metadata tracking helpers,
 - consumer and cutoff protocols,
+- entanglement-based key distribution,
 - switch-style protocols,
 - and QTCP-related controllers and message types.
 

--- a/src/ProtocolZoo/ProtocolZoo.jl
+++ b/src/ProtocolZoo/ProtocolZoo.jl
@@ -19,6 +19,7 @@ using PrettyTables: PrettyTables, pretty_table
 export
     # protocols
     EntanglerProt, SwapperProt, EntanglementTracker, EntanglementConsumer, CutoffProt,
+    BBM92Prot, sifted_key, qber,
     protocol_log_context,
     # tags
     EntanglementCounterpart, EntanglementHistory, EntanglementUpdateX, EntanglementUpdateZ,
@@ -910,6 +911,7 @@ using .Switches
 include("qtcp.jl")
 using .QTCP
 include("mbqc.jl")
+include("bbm92.jl")
 using .MBQCEntanglementDistillation
 
 _protocol_nodes(prot::EntanglementTracker) = (prot.node,)
@@ -917,6 +919,7 @@ _protocol_nodes(prot::SwapperProt) = (prot.node,)
 _protocol_nodes(prot::CutoffProt) = (prot.node,)
 _protocol_nodes(prot::EntanglerProt) = (prot.nodeA, prot.nodeB)
 _protocol_nodes(prot::EntanglementConsumer) = (prot.nodeA, prot.nodeB)
+_protocol_nodes(prot::BBM92Prot) = (prot.nodeA, prot.nodeB)
 
 _protocol_nodes(prot::Switches.SimpleSwitchDiscreteProt) =
     (prot.switchnode, Tuple(prot.clientnodes)...)

--- a/src/ProtocolZoo/bbm92.jl
+++ b/src/ProtocolZoo/bbm92.jl
@@ -1,0 +1,182 @@
+"""
+$TYPEDEF
+
+Entanglement-based quantum key distribution following Bennett, Brassard and Mermin 1992.
+
+Each round consumes one entangled pair shared between `nodeA` and `nodeB`, measures each
+half in a basis drawn independently and uniformly from `Z` and `X`, and records the two
+bases and the two outcomes. Rounds in which the two bases agree form the sifted key; the
+rest are discarded. [`sifted_key`](@ref) and [`qber`](@ref) read the recorded rounds.
+
+The pairs themselves are not produced here. Run an [`EntanglerProt`](@ref) (and a swapper,
+if the two nodes are not neighbours) so that reciprocal `EntanglementCounterpart` tags are
+present, exactly as [`EntanglementConsumer`](@ref) expects.
+
+Set `eavesdrop=true` to run an intercept-resend attacker on the `nodeB` arm: before the
+legitimate measurement the attacker measures in a basis of their own and re-prepares the
+half in the eigenstate they found. Their basis matches the legitimate one half of the time
+and randomises the outcome otherwise, so the sifted key picks up a quarter of errors. This
+is the textbook attack only, not a general security model. The attack is applied to the stored
+half as the pair is consumed rather than while it is in flight, which gives the same statistics
+here because nothing else acts on the pair in between.
+
+$FIELDS
+"""
+@kwdef struct BBM92Prot <: AbstractProtocol
+    """time-and-schedule-tracking instance from `ConcurrentSim`"""
+    sim::Simulation
+    """a network graph of registers"""
+    net::RegisterNet
+    """the vertex index of node A"""
+    nodeA::Int
+    """the vertex index of node B"""
+    nodeB::Int
+    """number of rounds to run, or `-1` to run until the simulation ends"""
+    rounds::Int = -1
+    """time period between successive queries for a shared pair (`nothing` to wait on a tag change instead)"""
+    period::Union{Float64,Nothing} = 0.1
+    """whether an intercept-resend attacker acts on the `nodeB` half before it is measured"""
+    eavesdrop::Bool = false
+    """recorded rounds; the storage type is not part of the public API and may change in future versions"""
+    _log::Vector{@NamedTuple{t::Float64, basisA::Symbol, basisB::Symbol, outcomeA::Int, outcomeB::Int, basisE::Symbol}} = @NamedTuple{t::Float64, basisA::Symbol, basisB::Symbol, outcomeA::Int, outcomeB::Int, basisE::Symbol}[]
+
+    function BBM92Prot(sim, net, nodeA, nodeB, rounds, period, eavesdrop, _log)
+        @domain isnothing(period) || period > 0
+        return new(sim, net, nodeA, nodeB, rounds, period, eavesdrop, _log)
+    end
+end
+
+function BBM92Prot(sim::Simulation, net::RegisterNet, nodeA::Int, nodeB::Int; kwargs...)
+    return BBM92Prot(; sim, net, nodeA, nodeB, kwargs...)
+end
+function BBM92Prot(net::RegisterNet, nodeA::Int, nodeB::Int; kwargs...)
+    return BBM92Prot(get_time_tracker(net), net, nodeA, nodeB; kwargs...)
+end
+
+permits_virtual_edge(::Type{BBM92Prot}) = true
+
+protocol_catalog_metadata(::Type{BBM92Prot}) = (
+    attachment = :edge,
+    attachment_fields = (node_a=:nodeA, node_b=:nodeB),
+    required_fields = (),
+)
+
+_bbm92_observable(basis::Symbol) = basis === :Z ? Z : X
+_bbm92_eigenstate(basis::Symbol, outcome::Int) =
+    basis === :Z ? (outcome == 1 ? Z1 : Z2) : (outcome == 1 ? X1 : X2)
+
+@resumable function (prot::BBM92Prot)()
+    regA = prot.net[prot.nodeA]
+    regB = prot.net[prot.nodeB]
+    remaining = prot.rounds
+    while remaining != 0
+        query1 = query(regA, EntanglementCounterpart, prot.nodeB, ❓, ❓; locked=false, assigned=true)
+        if isnothing(query1)
+            @debug(
+                "Entanglement unavailable",
+                _group=LOG_GROUPS.protocol,
+                event=:entanglement_unavailable,
+                protocol_log_context(prot)...,
+                src_node=prot.nodeA,
+                wait_mode=isnothing(prot.period) ? :tag_change : :fixed_delay,
+                retry_after_s=prot.period,
+            )
+            if isnothing(prot.period)
+                @yield onchange(regA, Tag)
+            else
+                @yield timeout(prot.sim, prot.period::Float64)
+            end
+            continue
+        end
+        pair_id = query1.tag[4]
+        query2 = query(regB, EntanglementCounterpart, prot.nodeA, query1.slot.idx, pair_id; locked=false, assigned=true)
+        if isnothing(query2)
+            @debug(
+                "Entanglement unavailable",
+                _group=LOG_GROUPS.protocol,
+                event=:entanglement_unavailable,
+                protocol_log_context(prot)...,
+                dst_node=prot.nodeB,
+                wait_mode=isnothing(prot.period) ? :tag_change : :fixed_delay,
+                retry_after_s=prot.period,
+            )
+            if isnothing(prot.period)
+                @yield onchange(regB, Tag)
+            else
+                @yield timeout(prot.sim, prot.period::Float64)
+            end
+            continue
+        end
+
+        q1 = query1.slot
+        q2 = query2.slot
+        @yield lock(q1) & lock(q2)
+        query1 = query(q1, EntanglementCounterpart, prot.nodeB, q2.idx, pair_id; locked=true, assigned=true)
+        query2 = query(q2, EntanglementCounterpart, prot.nodeA, q1.idx, pair_id; locked=true, assigned=true)
+        if isnothing(query1) || isnothing(query2)
+            @debug(
+                "Entanglement query was invalidated",
+                _group=LOG_GROUPS.protocol,
+                event=:query_invalidated,
+                protocol_log_context(prot)...,
+                slots=(q1.idx, q2.idx),
+                pair_id=pair_id,
+            )
+            unlock(q1)
+            unlock(q2)
+            continue
+        end
+        untag!(q1, query1.id)
+        untag!(q2, query2.id)
+
+        basisE = :none
+        if prot.eavesdrop
+            basisE = rand((:Z, :X))
+            outcomeE = project_traceout!(q2, _bbm92_observable(basisE))
+            initialize!(q2, _bbm92_eigenstate(basisE, outcomeE))
+        end
+
+        basisA = rand((:Z, :X))
+        basisB = rand((:Z, :X))
+        outcomeA = project_traceout!(q1, _bbm92_observable(basisA))
+        outcomeB = project_traceout!(q2, _bbm92_observable(basisB))
+        push!(prot._log, (; t=now(prot.sim), basisA, basisB, outcomeA, outcomeB, basisE))
+        @debug(
+            "Measured a BBM92 round",
+            _group=LOG_GROUPS.protocol,
+            event=:bbm92_round,
+            protocol_log_context(prot)...,
+            slots=(q1.idx, q2.idx),
+            pair_id=pair_id,
+            bases=(basisA, basisB),
+            sifted=basisA === basisB,
+        )
+
+        unlock(q1)
+        unlock(q2)
+        remaining -= 1
+    end
+end
+
+"""
+$TYPEDSIGNATURES
+
+The sifted key of a [`BBM92Prot`](@ref) run, as node A's outcomes over the rounds in which
+both nodes happened to measure in the same basis.
+"""
+sifted_key(prot::BBM92Prot) = [r.outcomeA for r in prot._log if r.basisA === r.basisB]
+
+"""
+$TYPEDSIGNATURES
+
+The quantum bit error rate of a [`BBM92Prot`](@ref) run, as the fraction of sifted rounds
+in which the two outcomes disagree. Returns `NaN` when no round has been sifted yet.
+
+On noiseless pairs this is zero. Under the intercept-resend attacker of `eavesdrop=true` it
+approaches `0.25`.
+"""
+function qber(prot::BBM92Prot)
+    sifted = [r for r in prot._log if r.basisA === r.basisB]
+    isempty(sifted) && return NaN
+    return count(r -> r.outcomeA != r.outcomeB, sifted) / length(sifted)
+end

--- a/test/general/protocolzoo_bbm92_tests.jl
+++ b/test/general/protocolzoo_bbm92_tests.jl
@@ -1,0 +1,66 @@
+using Test
+using QuantumSavory
+using QuantumSavory.ProtocolZoo: EntanglerProt, BBM92Prot, sifted_key, qber
+using ConcurrentSim
+using ResumableFunctions
+using Graphs
+using Random
+
+function bbm92_run(; eavesdrop=false, rounds=-1, T=40.0, seed=42)
+    Random.seed!(seed)
+    net = RegisterNet([Register(4), Register(4)]; classical_delay=1e-9)
+    sim = get_time_tracker(net)
+    @process EntanglerProt(sim, net, 1, 2; rounds=-1, success_prob=1.0)()
+    prot = BBM92Prot(sim, net, 1, 2; period=0.01, eavesdrop, rounds)
+    @process prot()
+    run(sim, T)
+    return prot
+end
+
+@testset "ProtocolZoo BBM92" begin
+
+@testset "noiseless pairs give a perfectly correlated sifted key" begin
+    prot = bbm92_run()
+    @test !isempty(prot._log)
+    @test qber(prot) == 0.0
+    sifted = [r for r in prot._log if r.basisA === r.basisB]
+    @test all(r -> r.outcomeA == r.outcomeB, sifted)
+    @test length(sifted_key(prot)) == length(sifted)
+    @test all(in((1, -1)), sifted_key(prot))
+end
+
+@testset "bases are chosen independently, so about half the rounds sift" begin
+    prot = bbm92_run()
+    n = length(prot._log)
+    @test 0.4 < length(sifted_key(prot)) / n < 0.6
+    @test all(r -> r.basisA in (:Z, :X) && r.basisB in (:Z, :X), prot._log)
+    @test all(r -> r.basisE === :none, prot._log)
+end
+
+@testset "intercept-resend leaves the textbook quarter of errors" begin
+    prot = bbm92_run(eavesdrop=true)
+    sifted = [r for r in prot._log if r.basisA === r.basisB]
+    @test length(sifted) > 300
+    @test 0.20 < qber(prot) < 0.30
+    @test all(r -> r.basisE in (:Z, :X), prot._log)
+
+    matched = [r for r in sifted if r.basisE === r.basisA]
+    crossed = [r for r in sifted if r.basisE !== r.basisA]
+    @test !isempty(matched) && !isempty(crossed)
+    @test all(r -> r.outcomeA == r.outcomeB, matched)
+    @test 0.4 < count(r -> r.outcomeA != r.outcomeB, crossed) / length(crossed) < 0.6
+end
+
+@testset "the round budget is respected" begin
+    prot = bbm92_run(rounds=7)
+    @test length(prot._log) == 7
+end
+
+@testset "qber is NaN before anything has been sifted" begin
+    net = RegisterNet([Register(1), Register(1)])
+    prot = BBM92Prot(get_time_tracker(net), net, 1, 2)
+    @test isnan(qber(prot))
+    @test isempty(sifted_key(prot))
+end
+
+end


### PR DESCRIPTION
@nenadilic84 got here first in #334 and it was closed for inactivity rather than on its merits, so this is the same protocol with a different implementation. If he wants to take his back up, this should give way to it.

Each round consumes one `EntanglementCounterpart` pair between two nodes, measures each half in a basis drawn independently from `Z` and `X`, and records both bases and both outcomes. `sifted_key` keeps the rounds where the two bases agreed, `qber` gives the disagreement rate among them. The pairs come from whatever is already producing them, so `EntanglerProt` and a swapper if the nodes are not neighbours, the same arrangement `EntanglementConsumer` expects.

`eavesdrop=true` runs the intercept-resend attack on the `nodeB` arm: the attacker measures in a basis of their own and re-prepares the half in the eigenstate they found, before the legitimate measurement happens. It acts on the stored half as the pair is consumed rather than while it is in flight, which gives the same statistics here because nothing else touches the pair in between.

That part is there because of the review on #334, which pointed out that a QKD protocol without an eavesdropper is not demonstrating the thing that makes QKD interesting. It also gives the protocol a number to check against. On noiseless pairs the sifted key is perfectly correlated and QBER is exactly 0. With the attacker running, QBER lands near the textbook 0.25.

The quarter is worth taking apart, since a rough 0.25 can come out of a wrong implementation too. Measuring the two cases separately over 20000 shots each:

| attacker's basis vs the measurement basis | outcomes agree | expected |
|---|---|---|
| matched | 1.0 exactly, both bases | 1 |
| conjugate | 0.4985 and 0.5027 | 0.5 |

so the attacker is invisible half the time and randomises the outcome the rest of the time, and the quarter is the average of those two. The tests assert the matched case exactly and put loose bounds on the statistical one.

No example or visualization yet. The review on #334 asked for screenshots and I would rather agree on the protocol first than guess at what the example should show.

Claiming one instance of the repeatable bounty in #137.

- [x] The code is properly formatted and commented.
- [x] Substantial new functionality is documented within the docs.
- [x] All new functionality is tested.
- [ ] All of the automated tests on github pass. Workflows need maintainer approval before they run, so this is not verified here yet. Locally the `general` suite is 15256 passing on Julia 1.12.
- [x] We recently started enforcing formatting checks. If formatting issues are reported in the new code you have written, please correct them.

If you are submitting for a bug bounty:
- [x] I have read and followed the [AI usage and disclosure policy](https://github.com/QuantumSavory/.github/blob/main/BUG_BOUNTIES.md)
