### PR TITLE
CI: cover Julia 1.12 and stabilize Buildkite setup and JET

### DIFF
--- a/.agents/context/workflows/testing.md
+++ b/.agents/context/workflows/testing.md
@@ -25,8 +25,9 @@
    Julia on macOS arm64 with one thread and Windows x64 with one. The downgrade
    workflow runs general on Julia 1.12 and excludes Aqua through the runner’s downgrade
    condition.
-   The Xvfb plugin uses job-local launchers and per-invocation displays; it does not
-   overwrite a shared launcher or terminate other jobs' Julia/Xvfb processes.
+   Buildkite uses the QuantumSavory Julia setup and Xvfb plugin releases for all jobs,
+   including the alpha job. The Xvfb plugin uses job-local launchers and per-invocation
+   displays; it does not overwrite a shared launcher or terminate other jobs' Julia/Xvfb processes.
    The JET step uses one Julia thread to avoid the compiler specialization-cache race
    tracked by JuliaLang/julia#62332; its analysis and assertions are unchanged.
 5. Check environment routing before diagnosing dependency failures. Root workspace

--- a/.agents/context/workflows/testing.md
+++ b/.agents/context/workflows/testing.md
@@ -28,6 +28,8 @@
    The Buildkite repository `pre-command` hook gives each agent its own Julia plugin
    cache to prevent concurrent installation and depot cleanup races. An explicit nonempty
    `BUILDKITE_PLUGIN_JULIA_CACHE_DIR` is preserved.
+   The Xvfb plugin uses job-local launchers and per-invocation displays; it does not
+   overwrite a shared launcher or terminate other jobs' Julia/Xvfb processes.
    The JET step uses one Julia thread to avoid the compiler specialization-cache race
    tracked by JuliaLang/julia#62332; its analysis and assertions are unchanged.
 5. Check environment routing before diagnosing dependency failures. Root workspace

--- a/.agents/context/workflows/testing.md
+++ b/.agents/context/workflows/testing.md
@@ -21,7 +21,8 @@
    current checkout passes.
 4. Run specialist shards when relevant. Buildkite defines general on stable and alpha,
    plus JET, examples, plotting, and docs. GitHub’s main CI runs only general on Linux
-   x64 with five threads, macOS arm64 with one, and Windows x64 with one. The downgrade
+   x64 with five threads on Julia 1.12 and the latest stable Julia, plus the latest stable
+   Julia on macOS arm64 with one thread and Windows x64 with one. The downgrade
    workflow runs general on Julia 1.12 and excludes Aqua through the runner’s downgrade
    condition.
 5. Check environment routing before diagnosing dependency failures. Root workspace

--- a/.agents/context/workflows/testing.md
+++ b/.agents/context/workflows/testing.md
@@ -28,6 +28,8 @@
    The Buildkite repository `pre-command` hook gives each agent its own Julia plugin
    cache to prevent concurrent installation and depot cleanup races. An explicit nonempty
    `BUILDKITE_PLUGIN_JULIA_CACHE_DIR` is preserved.
+   The JET step uses one Julia thread to avoid the compiler specialization-cache race
+   tracked by JuliaLang/julia#62332; its analysis and assertions are unchanged.
 5. Check environment routing before diagnosing dependency failures. Root workspace
    membership names nonexistent `test/projects/examples`, while the runner correctly
    uses `examples/`. Do not “fix” resolution by creating the missing directory.

--- a/.agents/context/workflows/testing.md
+++ b/.agents/context/workflows/testing.md
@@ -25,6 +25,9 @@
    Julia on macOS arm64 with one thread and Windows x64 with one. The downgrade
    workflow runs general on Julia 1.12 and excludes Aqua through the runner’s downgrade
    condition.
+   The Buildkite repository `pre-command` hook gives each agent its own Julia plugin
+   cache to prevent concurrent installation and depot cleanup races. An explicit nonempty
+   `BUILDKITE_PLUGIN_JULIA_CACHE_DIR` is preserved.
 5. Check environment routing before diagnosing dependency failures. Root workspace
    membership names nonexistent `test/projects/examples`, while the runner correctly
    uses `examples/`. Do not “fix” resolution by creating the missing directory.

--- a/.agents/context/workflows/testing.md
+++ b/.agents/context/workflows/testing.md
@@ -25,9 +25,6 @@
    Julia on macOS arm64 with one thread and Windows x64 with one. The downgrade
    workflow runs general on Julia 1.12 and excludes Aqua through the runner’s downgrade
    condition.
-   The Buildkite repository `pre-command` hook gives each agent its own Julia plugin
-   cache to prevent concurrent installation and depot cleanup races. An explicit nonempty
-   `BUILDKITE_PLUGIN_JULIA_CACHE_DIR` is preserved.
    The Xvfb plugin uses job-local launchers and per-invocation displays; it does not
    overwrite a shared launcher or terminate other jobs' Julia/Xvfb processes.
    The JET step uses one Julia thread to avoid the compiler specialization-cache race

--- a/.agents/context/workflows/testing.md
+++ b/.agents/context/workflows/testing.md
@@ -9,8 +9,8 @@
 
 1. Add discoverable tests with a filename ending `_tests.jl`. The
    ParallelTestRunner entry point finds Julia tests, then filters out every name without
-   that suffix. `test/test_stateszoo_depolarized.jl` is currently orphaned by
-   this rule despite containing a test item.
+   that suffix. Use ordinary `@testset` blocks, as in
+   `test/general/stateszoo_depolarized_tests.jl`.
 2. Run the smallest named test or prefix first through the package test entry point,
    then its shard. With no arguments the runner explicitly defaults to `general`.
    Prefixes route `plotting` tests to `test/projects/plotting`, `examples` tests to the
@@ -71,5 +71,4 @@ that claim.
 
 ## Unresolved questions
 
-- Should the orphaned depolarized-state file be renamed or merged into the existing API tests?
 - Should the root workspace point to `examples` instead of `test/projects/examples`?

--- a/.agents/context/zoos/states-catalog.md
+++ b/.agents/context/zoos/states-catalog.md
@@ -31,9 +31,9 @@ parameters; concrete state-object field layout is not the public contract.
 All five model types are covered by the API test’s default-QuantumOptics trace check,
 which does not establish every representation. Support is intentionally per-model and
 per-representation rather than universal.
-The separate Clifford check for `DepolarizedBellPair` lives in
-`test/test_stateszoo_depolarized.jl`, which the current `_tests.jl` filename filter does
-not discover. Only add an explicit `LinearAlgebra.tr` method when generic symbolic
+The separate constructor and backend checks for `DepolarizedBellPair` live in
+`test/general/stateszoo_depolarized_tests.jl` and run with the general suite.
+Only add an explicit `LinearAlgebra.tr` method when generic symbolic
 lowering is insufficient; the Barrett–Kok path needs specialization, but explicit
 trace methods are not a general StatesZoo requirement.
 
@@ -41,11 +41,10 @@ trace methods are not a general StatesZoo requirement.
 
 - **Source:** [`src/StatesZoo/StatesZoo.jl`](../../../src/StatesZoo/StatesZoo.jl), [`src/StatesZoo/barrett_kok.jl`](../../../src/StatesZoo/barrett_kok.jl), [`src/StatesZoo/depolarized.jl`](../../../src/StatesZoo/depolarized.jl), and [`src/StatesZoo/genqo.jl`](../../../src/StatesZoo/genqo.jl) — model definitions and lowering.
 - **Docs:** [`docs/src/API_StatesZoo.md`](../../../docs/src/API_StatesZoo.md) and [`docs/src/state_visualization.md`](../../../docs/src/state_visualization.md) — constructors, formulas, and exploration.
-- **Test:** [`test/general/stateszoo_api_tests.jl`](../../../test/general/stateszoo_api_tests.jl) and the currently orphaned [`test/test_stateszoo_depolarized.jl`](../../../test/test_stateszoo_depolarized.jl) — catalog surface and backend-specific evidence.
+- **Test:** [`test/general/stateszoo_api_tests.jl`](../../../test/general/stateszoo_api_tests.jl) and [`test/general/stateszoo_depolarized_tests.jl`](../../../test/general/stateszoo_depolarized_tests.jl) — catalog surface and backend-specific evidence.
 
 ## Known gaps
 
 - `BarrettKokBellPair` accepts and documents `m`, but its parameter/range
   introspection omits it; the weighted model's convenience constructors also lack
   constructor-parameter prose.
-- The Clifford depolarized-state test is not discovered by the test runner.

--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -1,6 +1,0 @@
-#!/usr/bin/env bash
-
-# Concurrent agents must not replace each other's Julia installs or clean shared depots.
-if [[ -z "${BUILDKITE_PLUGIN_JULIA_CACHE_DIR:-}" ]]; then
-    export BUILDKITE_PLUGIN_JULIA_CACHE_DIR="${HOME}/.cache/julia-buildkite-plugin/agents/${BUILDKITE_AGENT_ID}"
-fi

--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+# Concurrent agents must not replace each other's Julia installs or clean shared depots.
+if [[ -z "${BUILDKITE_PLUGIN_JULIA_CACHE_DIR:-}" ]]; then
+    export BUILDKITE_PLUGIN_JULIA_CACHE_DIR="${HOME}/.cache/julia-buildkite-plugin/agents/${BUILDKITE_AGENT_ID}"
+fi

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -25,6 +25,10 @@ steps:
           test_args: "general"
       - JuliaCI/julia-coverage#v1: ~
   - label: "JET Tests"
+    # Avoid the parallel compiler cache race until Julia includes this fix:
+    # https://github.com/JuliaLang/julia/pull/62332
+    env:
+      JULIA_NUM_THREADS: "1"
     plugins:
       - Krastanov-agent/julia#fb9fb9196677350a913f82a125113cc31238ad31:
           version: "1"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -4,23 +4,20 @@ env:
 secrets:
   - CODECOV_TOKEN
 
-# Pin portable hooks until these fixes are released:
-# https://github.com/JuliaCI/julia-buildkite-plugin/pull/64
-# https://github.com/QuantumSavory/julia-xvfb-buildkite-plugin/pull/1
 steps:
   - label: "General Tests"
     plugins:
-      - Krastanov-agent/julia#fb9fb9196677350a913f82a125113cc31238ad31:
+      - QuantumSavory/julia#v1.14:
           version: "1"
-      - Krastanov-agent/julia#e3d2132bfc3e67fa842bc3fed2d5e1bb59702a3e:
+      - QuantumSavory/julia-xvfb#v1.2:
       - JuliaCI/julia-test#v1:
           test_args: "general"
       - JuliaCI/julia-coverage#v1: ~
   - label: "General Tests (alpha)"
     plugins:
-      - Krastanov-agent/julia#02e5970063da49f1c9a2d04d3250b95fa3a9fb7b:
+      - QuantumSavory/julia#v1.14:
           version: "alpha"
-      - Krastanov-agent/julia#e3d2132bfc3e67fa842bc3fed2d5e1bb59702a3e:
+      - QuantumSavory/julia-xvfb#v1.2:
       - JuliaCI/julia-test#v1:
           test_args: "general"
       - JuliaCI/julia-coverage#v1: ~
@@ -30,25 +27,25 @@ steps:
     env:
       JULIA_NUM_THREADS: "1"
     plugins:
-      - Krastanov-agent/julia#fb9fb9196677350a913f82a125113cc31238ad31:
+      - QuantumSavory/julia#v1.14:
           version: "1"
-      - Krastanov-agent/julia#e3d2132bfc3e67fa842bc3fed2d5e1bb59702a3e:
+      - QuantumSavory/julia-xvfb#v1.2:
       - JuliaCI/julia-test#v1:
           test_args: "jet"
       - JuliaCI/julia-coverage#v1: ~
   - label: "Example Tests"
     plugins:
-      - Krastanov-agent/julia#fb9fb9196677350a913f82a125113cc31238ad31:
+      - QuantumSavory/julia#v1.14:
           version: "1"
-      - Krastanov-agent/julia#e3d2132bfc3e67fa842bc3fed2d5e1bb59702a3e:
+      - QuantumSavory/julia-xvfb#v1.2:
       - JuliaCI/julia-test#v1:
           test_args: "example"
       - JuliaCI/julia-coverage#v1: ~
   - label: "Plotting Tests"
     plugins:
-      - Krastanov-agent/julia#fb9fb9196677350a913f82a125113cc31238ad31:
+      - QuantumSavory/julia#v1.14:
           version: "1"
-      - Krastanov-agent/julia#e3d2132bfc3e67fa842bc3fed2d5e1bb59702a3e:
+      - QuantumSavory/julia-xvfb#v1.2:
       - JuliaCI/julia-test#v1:
           test_args: "plotting"
       - JuliaCI/julia-coverage#v1: ~
@@ -57,9 +54,9 @@ steps:
   - label: "Docs"
     branches: "!dependabot/*"
     plugins:
-      - Krastanov-agent/julia#fb9fb9196677350a913f82a125113cc31238ad31:
+      - QuantumSavory/julia#v1.14:
           version: "1"
-      - Krastanov-agent/julia#e3d2132bfc3e67fa842bc3fed2d5e1bb59702a3e:
+      - QuantumSavory/julia-xvfb#v1.2:
     secrets:
       - DOCUMENTER_KEY
       - ANYTHINGLLM_API_KEY

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -4,44 +4,47 @@ env:
 secrets:
   - CODECOV_TOKEN
 
+# Pin portable hooks until these fixes are released:
+# https://github.com/JuliaCI/julia-buildkite-plugin/pull/64
+# https://github.com/QuantumSavory/julia-xvfb-buildkite-plugin/pull/1
 steps:
   - label: "General Tests"
     plugins:
-      - JuliaCI/julia#v1:
+      - JuliaCI/julia#fb9fb9196677350a913f82a125113cc31238ad31:
           version: "1"
-      - QuantumSavory/julia-xvfb#v1:
+      - QuantumSavory/julia-xvfb#a92371896a8ab82b8cbd9a28973003df16a2f58d:
       - JuliaCI/julia-test#v1:
           test_args: "general"
       - JuliaCI/julia-coverage#v1: ~
   - label: "General Tests (alpha)"
     plugins:
-      - Krastanov-agent/julia#bb0dd898e0190fa025fa9eddbf5b39665edc8e6c:
+      - Krastanov-agent/julia#02e5970063da49f1c9a2d04d3250b95fa3a9fb7b:
           version: "alpha"
-      - QuantumSavory/julia-xvfb#v1:
+      - QuantumSavory/julia-xvfb#a92371896a8ab82b8cbd9a28973003df16a2f58d:
       - JuliaCI/julia-test#v1:
           test_args: "general"
       - JuliaCI/julia-coverage#v1: ~
   - label: "JET Tests"
     plugins:
-      - JuliaCI/julia#v1:
+      - JuliaCI/julia#fb9fb9196677350a913f82a125113cc31238ad31:
           version: "1"
-      - QuantumSavory/julia-xvfb#v1:
+      - QuantumSavory/julia-xvfb#a92371896a8ab82b8cbd9a28973003df16a2f58d:
       - JuliaCI/julia-test#v1:
           test_args: "jet"
       - JuliaCI/julia-coverage#v1: ~
   - label: "Example Tests"
     plugins:
-      - JuliaCI/julia#v1:
+      - JuliaCI/julia#fb9fb9196677350a913f82a125113cc31238ad31:
           version: "1"
-      - QuantumSavory/julia-xvfb#v1:
+      - QuantumSavory/julia-xvfb#a92371896a8ab82b8cbd9a28973003df16a2f58d:
       - JuliaCI/julia-test#v1:
           test_args: "example"
       - JuliaCI/julia-coverage#v1: ~
   - label: "Plotting Tests"
     plugins:
-      - JuliaCI/julia#v1:
+      - JuliaCI/julia#fb9fb9196677350a913f82a125113cc31238ad31:
           version: "1"
-      - QuantumSavory/julia-xvfb#v1:
+      - QuantumSavory/julia-xvfb#a92371896a8ab82b8cbd9a28973003df16a2f58d:
       - JuliaCI/julia-test#v1:
           test_args: "plotting"
       - JuliaCI/julia-coverage#v1: ~
@@ -50,9 +53,9 @@ steps:
   - label: "Docs"
     branches: "!dependabot/*"
     plugins:
-      - JuliaCI/julia#v1:
+      - JuliaCI/julia#fb9fb9196677350a913f82a125113cc31238ad31:
           version: "1"
-      - QuantumSavory/julia-xvfb#v1:
+      - QuantumSavory/julia-xvfb#a92371896a8ab82b8cbd9a28973003df16a2f58d:
     secrets:
       - DOCUMENTER_KEY
       - ANYTHINGLLM_API_KEY

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -10,9 +10,9 @@ secrets:
 steps:
   - label: "General Tests"
     plugins:
-      - JuliaCI/julia#fb9fb9196677350a913f82a125113cc31238ad31:
+      - Krastanov-agent/julia#fb9fb9196677350a913f82a125113cc31238ad31:
           version: "1"
-      - QuantumSavory/julia-xvfb#a92371896a8ab82b8cbd9a28973003df16a2f58d:
+      - Krastanov-agent/julia#a92371896a8ab82b8cbd9a28973003df16a2f58d:
       - JuliaCI/julia-test#v1:
           test_args: "general"
       - JuliaCI/julia-coverage#v1: ~
@@ -20,31 +20,31 @@ steps:
     plugins:
       - Krastanov-agent/julia#02e5970063da49f1c9a2d04d3250b95fa3a9fb7b:
           version: "alpha"
-      - QuantumSavory/julia-xvfb#a92371896a8ab82b8cbd9a28973003df16a2f58d:
+      - Krastanov-agent/julia#a92371896a8ab82b8cbd9a28973003df16a2f58d:
       - JuliaCI/julia-test#v1:
           test_args: "general"
       - JuliaCI/julia-coverage#v1: ~
   - label: "JET Tests"
     plugins:
-      - JuliaCI/julia#fb9fb9196677350a913f82a125113cc31238ad31:
+      - Krastanov-agent/julia#fb9fb9196677350a913f82a125113cc31238ad31:
           version: "1"
-      - QuantumSavory/julia-xvfb#a92371896a8ab82b8cbd9a28973003df16a2f58d:
+      - Krastanov-agent/julia#a92371896a8ab82b8cbd9a28973003df16a2f58d:
       - JuliaCI/julia-test#v1:
           test_args: "jet"
       - JuliaCI/julia-coverage#v1: ~
   - label: "Example Tests"
     plugins:
-      - JuliaCI/julia#fb9fb9196677350a913f82a125113cc31238ad31:
+      - Krastanov-agent/julia#fb9fb9196677350a913f82a125113cc31238ad31:
           version: "1"
-      - QuantumSavory/julia-xvfb#a92371896a8ab82b8cbd9a28973003df16a2f58d:
+      - Krastanov-agent/julia#a92371896a8ab82b8cbd9a28973003df16a2f58d:
       - JuliaCI/julia-test#v1:
           test_args: "example"
       - JuliaCI/julia-coverage#v1: ~
   - label: "Plotting Tests"
     plugins:
-      - JuliaCI/julia#fb9fb9196677350a913f82a125113cc31238ad31:
+      - Krastanov-agent/julia#fb9fb9196677350a913f82a125113cc31238ad31:
           version: "1"
-      - QuantumSavory/julia-xvfb#a92371896a8ab82b8cbd9a28973003df16a2f58d:
+      - Krastanov-agent/julia#a92371896a8ab82b8cbd9a28973003df16a2f58d:
       - JuliaCI/julia-test#v1:
           test_args: "plotting"
       - JuliaCI/julia-coverage#v1: ~
@@ -53,9 +53,9 @@ steps:
   - label: "Docs"
     branches: "!dependabot/*"
     plugins:
-      - JuliaCI/julia#fb9fb9196677350a913f82a125113cc31238ad31:
+      - Krastanov-agent/julia#fb9fb9196677350a913f82a125113cc31238ad31:
           version: "1"
-      - QuantumSavory/julia-xvfb#a92371896a8ab82b8cbd9a28973003df16a2f58d:
+      - Krastanov-agent/julia#a92371896a8ab82b8cbd9a28973003df16a2f58d:
     secrets:
       - DOCUMENTER_KEY
       - ANYTHINGLLM_API_KEY

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -12,7 +12,7 @@ steps:
     plugins:
       - Krastanov-agent/julia#fb9fb9196677350a913f82a125113cc31238ad31:
           version: "1"
-      - Krastanov-agent/julia#a92371896a8ab82b8cbd9a28973003df16a2f58d:
+      - Krastanov-agent/julia#e3d2132bfc3e67fa842bc3fed2d5e1bb59702a3e:
       - JuliaCI/julia-test#v1:
           test_args: "general"
       - JuliaCI/julia-coverage#v1: ~
@@ -20,7 +20,7 @@ steps:
     plugins:
       - Krastanov-agent/julia#02e5970063da49f1c9a2d04d3250b95fa3a9fb7b:
           version: "alpha"
-      - Krastanov-agent/julia#a92371896a8ab82b8cbd9a28973003df16a2f58d:
+      - Krastanov-agent/julia#e3d2132bfc3e67fa842bc3fed2d5e1bb59702a3e:
       - JuliaCI/julia-test#v1:
           test_args: "general"
       - JuliaCI/julia-coverage#v1: ~
@@ -32,7 +32,7 @@ steps:
     plugins:
       - Krastanov-agent/julia#fb9fb9196677350a913f82a125113cc31238ad31:
           version: "1"
-      - Krastanov-agent/julia#a92371896a8ab82b8cbd9a28973003df16a2f58d:
+      - Krastanov-agent/julia#e3d2132bfc3e67fa842bc3fed2d5e1bb59702a3e:
       - JuliaCI/julia-test#v1:
           test_args: "jet"
       - JuliaCI/julia-coverage#v1: ~
@@ -40,7 +40,7 @@ steps:
     plugins:
       - Krastanov-agent/julia#fb9fb9196677350a913f82a125113cc31238ad31:
           version: "1"
-      - Krastanov-agent/julia#a92371896a8ab82b8cbd9a28973003df16a2f58d:
+      - Krastanov-agent/julia#e3d2132bfc3e67fa842bc3fed2d5e1bb59702a3e:
       - JuliaCI/julia-test#v1:
           test_args: "example"
       - JuliaCI/julia-coverage#v1: ~
@@ -48,7 +48,7 @@ steps:
     plugins:
       - Krastanov-agent/julia#fb9fb9196677350a913f82a125113cc31238ad31:
           version: "1"
-      - Krastanov-agent/julia#a92371896a8ab82b8cbd9a28973003df16a2f58d:
+      - Krastanov-agent/julia#e3d2132bfc3e67fa842bc3fed2d5e1bb59702a3e:
       - JuliaCI/julia-test#v1:
           test_args: "plotting"
       - JuliaCI/julia-coverage#v1: ~
@@ -59,7 +59,7 @@ steps:
     plugins:
       - Krastanov-agent/julia#fb9fb9196677350a913f82a125113cc31238ad31:
           version: "1"
-      - Krastanov-agent/julia#a92371896a8ab82b8cbd9a28973003df16a2f58d:
+      - Krastanov-agent/julia#e3d2132bfc3e67fa842bc3fed2d5e1bb59702a3e:
     secrets:
       - DOCUMENTER_KEY
       - ANYTHINGLLM_API_KEY

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
+          - '1.12'
           - '1'
         os:
           - ubuntu-latest

--- a/test/general/stateszoo_depolarized_tests.jl
+++ b/test/general/stateszoo_depolarized_tests.jl
@@ -1,10 +1,10 @@
-@testitem "StatesZoo DepolarizedBellPair" begin
 using Test
 using QuantumSavory
 using QuantumSavory.StatesZoo
 using QuantumOpticsBase
-using QuantumClifford
 using LinearAlgebra
+
+@testset "StatesZoo DepolarizedBellPair" begin
 
 # p-constructor and fidelity-constructor consistency
 p = 0.7
@@ -31,10 +31,8 @@ initialize!(reg_c[1:2], DepolarizedBellPair(1.0))
 dm_mixed = express(DepolarizedBellPair(0.0))
 @test dm_mixed.data ≈ LinearAlgebra.I / 4
 
-# fidelity-to-p and p-to-fidelity roundtrip
+# The fidelity constructor preserves normalization.
 for F in [0.25, 0.5, 0.75, 1.0]
-    p_rt = (4F - 1) / 3
-    @test (3p_rt + 1) / 4 ≈ F
     dm = express(DepolarizedBellPair(F=F))
     @test tr(dm) ≈ 1
 end


### PR DESCRIPTION
Retain Julia 1.12 coverage and adopt the released Buildkite fixes from the QuantumSavory organization.

Changes:

- Add Julia 1.12 Linux general CI beside latest-stable Linux, macOS, and Windows.
- Use [QuantumSavory/julia v1.14](https://github.com/QuantumSavory/julia-buildkite-plugin/tree/v1.14) for every Buildkite job, including alpha. This release includes the portable Bash checks and named prerelease-channel support; separate unpublished stable/alpha fork pins are no longer needed.
- Use [QuantumSavory/julia-xvfb v1.2](https://github.com/QuantumSavory/julia-xvfb-buildkite-plugin/tree/v1.2), with platform guards and job-local launchers/displays instead of shared launchers and global process termination.
- Remove the temporary repository cache-isolation hook and its documentation, as the maintainer confirmed the concurrent-agent issue is fixed.
- Keep the JET-only one-thread mitigation for the Julia 1.13 compiler crash matching [JuliaLang/julia#62332](https://github.com/JuliaLang/julia/pull/62332). General-test thread settings are unchanged.
- Include the depolarized Bell-pair test restoration from #581 and synchronize the related agent documentation.

Validation of the release cleanup:

- Fresh recursive clones resolved Julia setup v1.14 to `dbd20b9d63930875b96dc7a048e57ffb437a0e4c` and Xvfb v1.2 to `21b53fb691b9452c8e4cc220bcd6ca34f04b19b2`.
- All four released shell hooks passed Bash 3.2 and Bash 5 syntax checks with their required `extglob` option.
- The released stable and alpha version resolvers ran successfully against the Julia release index.
- Parsed YAML comparison verified exactly 12 plugin-reference substitutions across six jobs. Julia versions, selectors, commands, secrets, and thread settings are preserved.
- `git diff --check` passed. Package tests were not rerun for this CI-reference/documentation cleanup; the pushed head starts a new CI run.

Earlier local audit of master `a38fbe6`: Julia 1.12.7 and 1.13.0 each passed 15,236 general assertions, 98 optional plotting/example assertions, JET, documentation generation without deployment, and 70 additional benchmark-fixture checks. Julia 1.12 minimum dependencies passed 15,224 assertions. The restored depolarized test passed its 11 assertions on both versions. These results precede the release-pin cleanup.

Audit caveats remain: the initial Julia 1.12 Aqua missing-marker failure passed unchanged focused and full reruns; public map tiles returned nonfatal HTTP 429; earlier native macOS GLFW crashes and macOS validation of the one-thread JET mitigation are not resolved by the successful Linux checks. No assertion, timeout, or coverage threshold was weakened.

No package behavior changes; no changelog entry required.
