### PR TITLE
Run depolarized Bell-pair tests in the general suite

### DIFF
--- a/.agents/context/workflows/testing.md
+++ b/.agents/context/workflows/testing.md
@@ -9,8 +9,8 @@
 
 1. Add discoverable tests with a filename ending `_tests.jl`. The
    ParallelTestRunner entry point finds Julia tests, then filters out every name without
-   that suffix. `test/test_stateszoo_depolarized.jl` is currently orphaned by
-   this rule despite containing a test item.
+   that suffix. Use ordinary `@testset` blocks, as in
+   `test/general/stateszoo_depolarized_tests.jl`.
 2. Run the smallest named test or prefix first through the package test entry point,
    then its shard. With no arguments the runner explicitly defaults to `general`.
    Prefixes route `plotting` tests to `test/projects/plotting`, `examples` tests to the
@@ -63,5 +63,4 @@ that claim.
 
 ## Unresolved questions
 
-- Should the orphaned depolarized-state file be renamed or merged into the existing API tests?
 - Should the root workspace point to `examples` instead of `test/projects/examples`?

--- a/.agents/context/zoos/states-catalog.md
+++ b/.agents/context/zoos/states-catalog.md
@@ -31,9 +31,9 @@ parameters; concrete state-object field layout is not the public contract.
 All five model types are covered by the API test’s default-QuantumOptics trace check,
 which does not establish every representation. Support is intentionally per-model and
 per-representation rather than universal.
-The separate Clifford check for `DepolarizedBellPair` lives in
-`test/test_stateszoo_depolarized.jl`, which the current `_tests.jl` filename filter does
-not discover. Only add an explicit `LinearAlgebra.tr` method when generic symbolic
+The separate constructor and backend checks for `DepolarizedBellPair` live in
+`test/general/stateszoo_depolarized_tests.jl` and run with the general suite.
+Only add an explicit `LinearAlgebra.tr` method when generic symbolic
 lowering is insufficient; the Barrett–Kok path needs specialization, but explicit
 trace methods are not a general StatesZoo requirement.
 
@@ -41,11 +41,10 @@ trace methods are not a general StatesZoo requirement.
 
 - **Source:** [`src/StatesZoo/StatesZoo.jl`](../../../src/StatesZoo/StatesZoo.jl), [`src/StatesZoo/barrett_kok.jl`](../../../src/StatesZoo/barrett_kok.jl), [`src/StatesZoo/depolarized.jl`](../../../src/StatesZoo/depolarized.jl), and [`src/StatesZoo/genqo.jl`](../../../src/StatesZoo/genqo.jl) — model definitions and lowering.
 - **Docs:** [`docs/src/API_StatesZoo.md`](../../../docs/src/API_StatesZoo.md) and [`docs/src/state_visualization.md`](../../../docs/src/state_visualization.md) — constructors, formulas, and exploration.
-- **Test:** [`test/general/stateszoo_api_tests.jl`](../../../test/general/stateszoo_api_tests.jl) and the currently orphaned [`test/test_stateszoo_depolarized.jl`](../../../test/test_stateszoo_depolarized.jl) — catalog surface and backend-specific evidence.
+- **Test:** [`test/general/stateszoo_api_tests.jl`](../../../test/general/stateszoo_api_tests.jl) and [`test/general/stateszoo_depolarized_tests.jl`](../../../test/general/stateszoo_depolarized_tests.jl) — catalog surface and backend-specific evidence.
 
 ## Known gaps
 
 - `BarrettKokBellPair` accepts and documents `m`, but its parameter/range
   introspection omits it; the weighted model's convenience constructors also lack
   constructor-parameter prose.
-- The Clifford depolarized-state test is not discovered by the test runner.

--- a/test/general/stateszoo_depolarized_tests.jl
+++ b/test/general/stateszoo_depolarized_tests.jl
@@ -1,10 +1,11 @@
-@testitem "StatesZoo DepolarizedBellPair" begin
 using Test
 using QuantumSavory
 using QuantumSavory.StatesZoo
 using QuantumOpticsBase
 using QuantumClifford
 using LinearAlgebra
+
+@testset "StatesZoo DepolarizedBellPair" begin
 
 # p-constructor and fidelity-constructor consistency
 p = 0.7
@@ -31,10 +32,8 @@ initialize!(reg_c[1:2], DepolarizedBellPair(1.0))
 dm_mixed = express(DepolarizedBellPair(0.0))
 @test dm_mixed.data ≈ LinearAlgebra.I / 4
 
-# fidelity-to-p and p-to-fidelity roundtrip
+# The fidelity constructor preserves normalization.
 for F in [0.25, 0.5, 0.75, 1.0]
-    p_rt = (4F - 1) / 3
-    @test (3p_rt + 1) / 4 ≈ F
     dm = express(DepolarizedBellPair(F=F))
     @test tr(dm) ≈ 1
 end

--- a/test/general/stateszoo_depolarized_tests.jl
+++ b/test/general/stateszoo_depolarized_tests.jl
@@ -2,7 +2,6 @@ using Test
 using QuantumSavory
 using QuantumSavory.StatesZoo
 using QuantumOpticsBase
-using QuantumClifford
 using LinearAlgebra
 
 @testset "StatesZoo DepolarizedBellPair" begin


### PR DESCRIPTION
The depolarized Bell-pair test file used `@testitem` and did not match the runner's `_tests.jl` filter, so the general suite never ran its constructor and backend checks. Move it into `test/general/` and use `@testset` so the existing ParallelTestRunner suite executes those checks. Remove the unused `QuantumClifford` import that makes `Register` ambiguous, remove a redundant algebra-only assertion, and update the related agent documentation.

This PR is stacked on #580 so the branch includes the corrected Buildkite hooks and Julia 1.12 general-test matrix while keeping this test migration's review diff separate. Merge #580 first, then retarget this PR to `master`. The diff against #580 contains only the test migration and its documentation.

Validation: focused `Pkg.test(; test_args=["--jobs=1", "general/stateszoo_depolarized"])` passes all 11 assertions locally on both Julia 1.12.7 and 1.13.0. For audit coverage, the original test body also passes all 15 assertions on both versions when an external harness explicitly imports `QuantumSavory: Register`; without that correction, it reproduces the import ambiguity on both versions.

Separately, unchanged master `a38fbe6380e5004980a18203d69cb848beb30f00` passes the full local general suite (15,236 assertions), optional plotting/examples suites (98 assertions), JET, and docs on both versions. These baseline full-suite runs did not include the newly restored test. `git diff --check` passes, and independent review found no blocking issues.

CI status at approximately 03:10 UTC: Julia 1.13 Ubuntu/macOS general tests pass with 15,247 assertions each; Julia 1.12 Ubuntu and Windows are still running. `codecov/project` is red because it compares only two head uploads against nine base uploads (71.61% versus 79.98%, with different measured-line counts). The public upload API confirms the base has five Buildkite and four GitHub general uploads; the head has only two GitHub general uploads. Comparable individual general-only coverage improves from 71.48% (2,385/3,336) to 71.61% (2,389/3,336), and patch coverage passes. The missing Buildkite suites supply optional Makie coverage that pending general uploads cannot provide. No Buildkite check is visible on this stacked head. This is unequal suite aggregation, not a test/assertion or source-coverage regression. After merging #580 and retargeting this PR, check the full resulting CI/coverage set; a same-head Buildkite run would also provide the missing suite uploads. Benchmark/downgrade base filters are a separate issue and neither uploads coverage. No coverage threshold was weakened.
