### PR TITLE
Run Aqua before the parallel general tests

### DIFF
--- a/.agents/context/workflows/testing.md
+++ b/.agents/context/workflows/testing.md
@@ -16,6 +16,8 @@
    Prefixes route `plotting` tests to `test/projects/plotting`, `examples` tests to the
    top-level `examples` project, and `jet` to `test/projects/jet`; JET executes directly
    while other tests use ParallelTestRunner.
+   When selected, `general/aqua_tests` runs serially before the parallel tests so its
+   precompilation processes do not overlap their workers.
 3. Finish cross-cutting changes with general tests. Record the command and actual
    outcome; repository configuration and historical CI jobs are not evidence that a
    current checkout passes.

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -33,4 +33,4 @@ ThreadTools = "dbf13d8f-d36e-4350-8970-f3a99faba1a8"
 
 [compat]
 FileIO = "1.20.0"
-ParallelTestRunner = "2.6.3"
+ParallelTestRunner = "2.7"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -60,5 +60,7 @@ else
     using Pkg
     Pkg.precompile()
     using QuantumSavory
-    runtests(QuantumSavory, args; testsuite, test_worker)
+    # Aqua starts additional precompilation processes. Run it before the parallel
+    # tests to keep their workers from competing for memory.
+    runtests(QuantumSavory, args; testsuite, test_worker, serial=["general/aqua_tests"])
 end


### PR DESCRIPTION
Run Aqua before the other general tests, using ParallelTestRunner's serial phase, and require ParallelTestRunner 2.7 for that API. This prevents Aqua's additional precompilation processes from overlapping the other test workers. All Aqua assertions remain enabled, and the remaining tests still run in parallel. Update the contributor testing notes to match.

The [current Julia 1.12 CI job](https://github.com/QuantumSavory/QuantumSavory.jl/actions/runs/34669210633/job/103487215858) passes the other 15,246 assertions but fails because Aqua's precompilation subprocess exits before creating `done.log`. The same failure occurred on Linux and Windows in [an earlier run](https://github.com/QuantumSavory/QuantumSavory.jl/actions/runs/34354420658). An isolated local Aqua run succeeds. Memory contention is a suspected cause. This change reduces concurrent memory use; the CI logs do not establish the underlying subprocess exit cause.

Validation: the complete general suite passed all 15,247 assertions across 65 test files on Julia 1.12.7 through `Pkg.test`, with GitHub CI's coverage, bounds, compiled-modules, and depwarn options and four parallel workers. Aqua passed before the parallel batch. The focused Aqua, register-interface, and superdense-coding run also passed 44/44 assertions on Julia 1.12.6. Independent review and `git diff --check` pass.

The PR's [Julia 1.12 Linux job](https://github.com/QuantumSavory/QuantumSavory.jl/actions/runs/34671354223/job/103493170817) and [latest-stable Linux job](https://github.com/QuantumSavory/QuantumSavory.jl/actions/runs/34671354223/job/103493170759) both pass, including the configuration that failed on master.
